### PR TITLE
Added an extra resource note for a component version of animate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,4 @@ rollOut
 ## Other Resources
 
 - There's a [Ruby gem](https://github.com/camelmasa/animate-rails) available for Animate.css
+- There's also a [component](https://github.com/jheytompkins/animate) version of Animate.css for use with the [component](https://github.com/component/component) package manager.


### PR DESCRIPTION
Added a resource note for the component version of Animate.css(https://github.com/jheytompkins/animate) for use with the component package manager(https://github.com/component/component).
