### PR TITLE
Fixed bug in Chrome

### DIFF
--- a/source/bouncing_entrances/bounceIn.css
+++ b/source/bouncing_entrances/bounceIn.css
@@ -14,6 +14,7 @@
 	}
 
 	100% {
+		opacity: 1;
 		transform: scale(1);
 	}
 }


### PR DESCRIPTION
Fixed bug in Chrome where opacity is reverted back after 50%. (If I set an object to have 0 opacity then play the animation/apply the class, the object disappears when it is complete). This does not change the animation but prevents the bug from happening.
