### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $('#yourElement').addClass('animated bounceOutLeft');
 You can also detect when an animation ends:
 
 ```javascript
-$('#yourElement').one('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', doSomething());
+$('#yourElement').on('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', doSomething);
 ```
 
 You can change the duration of your animations, add a delay or change the number of times that it plays:


### PR DESCRIPTION
`one` typo changed to `on` on animation end event and removed invocation brackets, as they shouldn't be there.
