### PR TITLE
zoom-exit: zoomOutBig

### DIFF
--- a/source/zooming_exits/zoomOutBig.css
+++ b/source/zooming_exits/zoomOutBig.css
@@ -1,0 +1,19 @@
+.zoomOutBig {
+  animation-name: zoomOutBig;
+}
+
+@keyframes zoomOutBig {
+  0% {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  80% {
+    opacity: 0;
+  }
+  
+  100% {
+    opacity: 0;
+    transform: scale(2);
+  }
+}


### PR DESCRIPTION
Zoom exit; zooms and fades the object. :]

Example (first animation just added as example for integration `zoomOutBig`) :
![zoomoutbig](https://cloud.githubusercontent.com/assets/5861085/3339587/0efd6faa-f86f-11e3-879c-3d791ae35a85.gif)
