### PR TITLE
Fix bower version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
   "name": "animate.css",
-  "version": "3.1.1",
+  "version": "3.2.1",
   "main": "./animate.css"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "animate.css",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-autoprefixer": "~0.4.0",


### PR DESCRIPTION
Bump both package.json and bower.json to keep in sync

Currently `bower.json` in the 3.2 tag says the version is 3.1.1. This will update both versions so they are correct, otherwise you'd have to re-tag 3.2 and that is not possible with npm.
