### PR TITLE
Tiny typo in animate-config.json

### DIFF
--- a/animate-config.json
+++ b/animate-config.json
@@ -60,8 +60,8 @@
   },
 
   "lightspeed": {
-    "lightspeedIn": true,
-    "lightspeedOut": true
+    "lightSpeedIn": true,
+    "lightSpeedOut": true
   },
 
   "rotating_entrances": {


### PR DESCRIPTION
The filenames are case-sensitive, right?

Found the issue because I copied all the classNames from this file so that I could apply random animations in my JS.  The `"animationend"` callbacks failed once in a while - found it was because the `lightSpeedIn` and `lightSpeedOut` didn't have the same case in this file vs. in `animate.css`, so the CSS animations were never getting triggered, thus no `"animationend"` event..  Also, looking at the Gruntfile, and the `lightSpeedIn.css` and `lightSpeedOut.css` filenames, it looks like this file needs to be corrected anyway.  Hopefully this will help people avoid the bug I created, and also improve the build script.
