### PR TITLE
Back exists → Back exits

### DIFF
--- a/animate.css
+++ b/animate.css
@@ -1034,7 +1034,7 @@
   -webkit-animation-name: backInUp;
   animation-name: backInUp;
 }
-/* Back exists */
+/* Back exits */
 @-webkit-keyframes backOutDown {
   0% {
     -webkit-transform: scale(1);

--- a/docs/index.html
+++ b/docs/index.html
@@ -158,7 +158,7 @@
     
 
       <section class="back_exists" id="back_exists">
-        <h3 class="animation-title">Back exists</h3>
+        <h3 class="animation-title">Back exits</h3>
         <ul class="animation-group">
     <li class="animation-item" data-animation="backOutDown">
       <span class="animation-item--title">backOutDown</span>

--- a/source/animate.css
+++ b/source/animate.css
@@ -21,7 +21,7 @@
 @import 'back_entrances/backInRight.css';
 @import 'back_entrances/backInUp.css';
 
-/* Back exists */
+/* Back exits */
 @import 'back_exits/backOutDown.css';
 @import 'back_exits/backOutLeft.css';
 @import 'back_exits/backOutRight.css';


### PR DESCRIPTION
Hi, @daneden and @eltonmesquita! 👋🏻

This (tiny) pull request fixes a typo where *Back exits* was written as *Back exists*.

Awesome job on getting the new organization and site online. 🥳