### PR TITLE
Removes unnecessary files from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,11 @@
     "hooks": {
       "pre-commit": "npm-run-all start precommit"
     }
-  }
+  },
+  "files": [
+    "animate.compat.css",
+    "animate.min.css",
+    "animate.css",
+    "source/**/*.css"
+  ]
 }


### PR DESCRIPTION
As we moved for a pure Postcss building on the new release, Parcel was breaking, as it was reading our `postcss.config.js` file and it can't read functions. See #1056.

This PR leaves only the CSS files, including the full source folder, when publishing to npm.