### PR TITLE
Suggesting using addEventListener once option in docs

### DIFF
--- a/docsSource/sections/04-javascript.md
+++ b/docsSource/sections/04-javascript.md
@@ -37,14 +37,12 @@ const animateCSS = (element, animation, prefix = 'animate__') =>
     node.classList.add(`${prefix}animated`, animationName);
 
     // When the animation ends, we clean the classes and resolve the Promise
-    function handleAnimationEnd() {
+    handleAnimationEnd = () => {
       node.classList.remove(`${prefix}animated`, animationName);
-      node.removeEventListener('animationend', handleAnimationEnd);
-
       resolve('Animation ended');
     }
 
-    node.addEventListener('animationend', handleAnimationEnd);
+    node.addEventListener('animationend', handleAnimationEnd, {once : true});
   });
 ```
 


### PR DESCRIPTION
Adding `{once : true}` to `node.addEventListener` causes the event trigger to be removed after first use. This built-in method cleans up the requirement to remove event within event handler.