### PR TITLE
docs: Fix simple typo, globaly -> globally

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -902,7 +902,7 @@
   --animate-duration: 2s;
 }
 
-/* This changes all the animations globaly */
+/* This changes all the animations globally */
 :root {
   --animate-duration: 800ms;
   --animate-delay: 0.9s;
@@ -996,7 +996,7 @@ document.documentElement.style.setProperty('--animate-duration', '.5s');
 </tr>
 </tbody>
 </table>
-<p>The <code>animate__animated</code> class has a default speed of <code>1s</code>. You can also customize the animations duration through the <code>--animate-duration</code> property, globaly or locally. This will affect both the animations and the utility classes. Example:</p>
+<p>The <code>animate__animated</code> class has a default speed of <code>1s</code>. You can also customize the animations duration through the <code>--animate-duration</code> property, globally or locally. This will affect both the animations and the utility classes. Example:</p>
 <pre><code class="language-css">/* All animations will take twice as long to finish */
 :root {
   --animate-duration: 2s;

--- a/docsSource/sections/01-usage.md
+++ b/docsSource/sections/01-usage.md
@@ -67,7 +67,7 @@ Example:
   --animate-duration: 2s;
 }
 
-/* This changes all the animations globaly */
+/* This changes all the animations globally */
 :root {
   --animate-duration: 800ms;
   --animate-delay: 0.9s;

--- a/docsSource/sections/02-utilities.md
+++ b/docsSource/sections/02-utilities.md
@@ -48,7 +48,7 @@ You can control the speed of the animation by adding these classes, as below:
 | `animate__fast`   | `800ms`            |
 | `animate__faster` | `500ms`            |
 
-The `animate__animated` class has a default speed of `1s`. You can also customize the animations duration through the `--animate-duration` property, globaly or locally. This will affect both the animations and the utility classes. Example:
+The `animate__animated` class has a default speed of `1s`. You can also customize the animations duration through the `--animate-duration` property, globally or locally. This will affect both the animations and the utility classes. Example:
 
 ```css
 /* All animations will take twice as long to finish */


### PR DESCRIPTION
There is a small typo in docsSource/sections/01-usage.md, docsSource/sections/02-utilities.md.

Should read `globally` rather than `globaly`.

