### PR TITLE
Improvement of animationend event

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1121,7 +1121,8 @@ element.style.setProperty('--animate-duration', '0.5s');
     node.classList.add(`${prefix}animated`, animationName);
 
     // When the animation ends, we clean the classes and resolve the Promise
-    function handleAnimationEnd() {
+    function handleAnimationEnd(event) {
+      event.stopPropagation();
       node.classList.remove(`${prefix}animated`, animationName);
       resolve('Animation ended');
     }

--- a/docsSource/sections/04-javascript.md
+++ b/docsSource/sections/04-javascript.md
@@ -37,7 +37,8 @@ const animateCSS = (element, animation, prefix = 'animate__') =>
     node.classList.add(`${prefix}animated`, animationName);
 
     // When the animation ends, we clean the classes and resolve the Promise
-    function handleAnimationEnd() {
+    function handleAnimationEnd(event) {
+      event.stopPropagation();
       node.classList.remove(`${prefix}animated`, animationName);
       resolve('Animation ended');
     }


### PR DESCRIPTION
If you use this event in a chain, an unobvious error will occur, which will take a lot of time while searching for it. The animation event goes through the parents and about such a piece of code can reproduce the problem, why it is done this way.

```
animateCSS('.modals > .modal', 'fadeOutLeft').then(() => {
    $('.modals > .modal').removeClass('shown');
    return animateCSS('.modals', 'fadeOut');
}).then(() => {
    $('.modals').removeClass('shown');
});
```