### PR TITLE
Update 04-javascript.md

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1114,7 +1114,7 @@ element.style.setProperty('--animate-duration', '0.5s');
 <p>You can also use a simple function to add the animations classes and remove them automatically:</p>
 <pre><code class="language-javascript">const animateCSS = (element, animation, prefix = 'animate__') =&gt;
   // We create a Promise and return it
-  return new Promise((resolve, reject) =&gt; {
+  new Promise((resolve, reject) =&gt; {
     const animationName = `${prefix}${animation}`;
     const node = document.querySelector(element);
 

--- a/docsSource/sections/04-javascript.md
+++ b/docsSource/sections/04-javascript.md
@@ -30,7 +30,7 @@ You can also use a simple function to add the animations classes and remove them
 ```javascript
 const animateCSS = (element, animation, prefix = 'animate__') =>
   // We create a Promise and return it
-  return new Promise((resolve, reject) => {
+  new Promise((resolve, reject) => {
     const animationName = `${prefix}${animation}`;
     const node = document.querySelector(element);
 


### PR DESCRIPTION
this arrow function uses implicit return. an explicit `return` throws an error.