### PR TITLE
fix: 🐛 allow lint-staged works with .mjs files

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "prettier": "^2.2.1"
   },
   "lint-staged": {
-    "*.{js,json,md,css}": [
+    "*.{mjs,js,json,md,css}": [
       "prettier --write"
     ]
   },


### PR DESCRIPTION
Hello, 
This PR is a simple fix at package.json that will allow `lint-staged` rules works with `.mjs` files. 