### PR TITLE
Added missing to opacity 1 for entrance animations

### DIFF
--- a/source/bouncing_entrances/bounceInDown.css
+++ b/source/bouncing_entrances/bounceInDown.css
@@ -26,6 +26,7 @@
   }
 
   to {
+    opacity: 1;
     transform: translate3d(0, 0, 0);
   }
 }

--- a/source/bouncing_entrances/bounceInLeft.css
+++ b/source/bouncing_entrances/bounceInLeft.css
@@ -26,6 +26,7 @@
   }
 
   to {
+    opacity: 1;
     transform: translate3d(0, 0, 0);
   }
 }

--- a/source/bouncing_entrances/bounceInRight.css
+++ b/source/bouncing_entrances/bounceInRight.css
@@ -26,6 +26,7 @@
   }
 
   to {
+    opacity: 1;
     transform: translate3d(0, 0, 0);
   }
 }

--- a/source/bouncing_entrances/bounceInUp.css
+++ b/source/bouncing_entrances/bounceInUp.css
@@ -26,6 +26,7 @@
   }
 
   to {
+    opacity: 1;
     transform: translate3d(0, 0, 0);
   }
 }

--- a/source/flippers/flipInX.css
+++ b/source/flippers/flipInX.css
@@ -20,6 +20,7 @@
   }
 
   to {
+    opacity: 1;
     transform: perspective(400px);
   }
 }

--- a/source/flippers/flipInY.css
+++ b/source/flippers/flipInY.css
@@ -20,6 +20,7 @@
   }
 
   to {
+    opacity: 1;
     transform: perspective(400px);
   }
 }

--- a/source/lightspeed/lightSpeedInLeft.css
+++ b/source/lightspeed/lightSpeedInLeft.css
@@ -14,6 +14,7 @@
   }
 
   to {
+    opacity: 1;
     transform: translate3d(0, 0, 0);
   }
 }

--- a/source/lightspeed/lightSpeedInRight.css
+++ b/source/lightspeed/lightSpeedInRight.css
@@ -14,6 +14,7 @@
   }
 
   to {
+    opacity: 1;
     transform: translate3d(0, 0, 0);
   }
 }

--- a/source/zooming_entrances/zoomIn.css
+++ b/source/zooming_entrances/zoomIn.css
@@ -7,6 +7,10 @@
   50% {
     opacity: 1;
   }
+
+  to {
+    opacity: 1;
+  }
 }
 
 .zoomIn {

--- a/source/zooming_entrances/zoomInDown.css
+++ b/source/zooming_entrances/zoomInDown.css
@@ -10,6 +10,10 @@
     transform: scale3d(0.475, 0.475, 0.475) translate3d(0, 60px, 0);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
   }
+
+  to {
+    opacity: 1;
+  }
 }
 
 .zoomInDown {

--- a/source/zooming_entrances/zoomInLeft.css
+++ b/source/zooming_entrances/zoomInLeft.css
@@ -10,6 +10,10 @@
     transform: scale3d(0.475, 0.475, 0.475) translate3d(10px, 0, 0);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
   }
+
+  to {
+    opacity: 1;
+  }
 }
 
 .zoomInLeft {

--- a/source/zooming_entrances/zoomInRight.css
+++ b/source/zooming_entrances/zoomInRight.css
@@ -10,6 +10,10 @@
     transform: scale3d(0.475, 0.475, 0.475) translate3d(-10px, 0, 0);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
   }
+
+  to {
+    opacity: 1;
+  }
 }
 
 .zoomInRight {

--- a/source/zooming_entrances/zoomInUp.css
+++ b/source/zooming_entrances/zoomInUp.css
@@ -10,6 +10,10 @@
     transform: scale3d(0.475, 0.475, 0.475) translate3d(0, -60px, 0);
     animation-timing-function: cubic-bezier(0.175, 0.885, 0.32, 1);
   }
+
+  to {
+    opacity: 1;
+  }
 }
 
 .zoomInUp {


### PR DESCRIPTION
I am triggering animations via JS once the element scrolls into view. For most entrance animations, this means that I need to add `opacity:0` to the element so that we do not see the elements until I trigger the animation. 

Several of the entrance animations stopped animating opacity part way through the animation. Therefore, this would generate a flash during from where `opacity:1` was set until the end of the animation. The fix was simply to make sure that the opacity is set to 1 all the way to the end of the animation inside of the `to` block. 