### PR TITLE
Add badge for huntr.dev bounty program

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Animate.css
+# Animate.css [![huntr](https://cdn.huntr.dev/huntr_security_badge_mono.svg)](https://huntr.dev)
 
 [![GitHub Version](https://img.shields.io/github/release/animate-css/animate.css.svg?style=for-the-badge)](https://github.com/animate-css/animate.css/releases) [![Github Star](https://img.shields.io/github/stars/animate-css/animate.css.svg?style=for-the-badge)](https://github.com/animate-css/animate.css/stargazers) [![Github Fork](https://img.shields.io/github/forks/animate-css/animate.css.svg?style=for-the-badge)](https://github.com/animate-css/animate.css/network/members) [![License](https://img.shields.io/github/license/animate-css/animate.css.svg?style=for-the-badge)](https://github.com/animate-css/animate.css/blob/main/LICENSE)
 


### PR DESCRIPTION
I want to add this as we have a security file in the repository. We don't have any bug bounty program and I found huntr.dev can help us on keeping animate.css secure. I add a badge so everyone that discovers a potential security issue can directly report to huntr.dev. This is the current value of animate.css from their platform.

![image](https://user-images.githubusercontent.com/15052701/136005856-d4654143-431e-4892-877e-7e63cbf6ed45.png)

You can also contact us via SECURITY.md file located at the root of this repo.

What do you think @eltonmesquita @daneden ?