### PR TITLE
Update 04-javascript.md

### DIFF
--- a/docsSource/sections/04-javascript.md
+++ b/docsSource/sections/04-javascript.md
@@ -43,7 +43,9 @@ const animateCSS = (element, animation, prefix = 'animate__') =>
       resolve('Animation ended');
     }
 
-    node.addEventListener('animationend', handleAnimationEnd, {once: true});
+      ['animationend', 'webkitAnimationEnd', 'oAnimationEnd'].forEach((e) => {
+      node.addEventListener(e, handleAnimationEnd, {once: true});
+    });
   });
 ```
 


### PR DESCRIPTION
The event animationend isn't enough for triggering handleAnimationEnd in Google Chrome so it was added webkitAnimationEnd and oAnimationEnd.