### PR TITLE
✨ TWEAK: update SPDX license ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "name": "Animate.css"
   },
   "homepage": "https://animate.style/",
-  "license": "HL-2.1",
+  "license": "Hippocratic-2.1",
   "animateConfig": {
     "prefix": "animate__"
   },


### PR DESCRIPTION
I'm seeing a warning for not using a valid license. So I updated the valid identifier which is `Hippocratic-2.1` in the `package.json` file. Check some references below.

---

- [SPDX License ID](https://spdx.org/licenses/Hippocratic-2.1.html)
- [Hippocratic license incorrectly identified as invalid SPDX expression](https://github.com/npm/cli/issues/1724)