### PR TITLE
Move from Travis CI to Github Actions #1221

### DIFF
--- a/.github/workflows/install-start-run.yml
+++ b/.github/workflows/install-start-run.yml
@@ -1,0 +1,29 @@
+name: Install Start Run CI
+
+on:
+  push:
+    branches: [$default-branch]
+  pull_request:
+    branches: [$default-branch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - run: npm run build --if-present
+      - run: npm test
+      - run: npm install
+      - run: npm start
+      - run: npm run docs


### PR DESCRIPTION
I had some spare time and use your animations so much, I thought I'd contribute. 

I set up a Github Workflow called Install Start Run, which will       
- run: npm run build --if-present
      - run: npm test
      - run: npm install
      - run: npm start
      - run: npm run docs

I did not delete the Travis CI, however it could also be done.

Reference: https://github.com/animate-css/animate.css/issues/1221