### PR TITLE
Update animate.css

### DIFF
--- a/animate.css
+++ b/animate.css
@@ -1650,14 +1650,18 @@
     -webkit-transform: scale3d(0.3, 0.3, 0.3);
     transform: scale3d(0.3, 0.3, 0.3);
   }
+:root {
+  --animate-duration: 1s;
 }
-.animate__bounceOut {
-  -webkit-animation-duration: calc(1s * 0.75);
-  animation-duration: calc(1s * 0.75);
+
+.var.animate__bounceOut {
   -webkit-animation-duration: calc(var(--animate-duration) * 0.75);
   animation-duration: calc(var(--animate-duration) * 0.75);
   -webkit-animation-name: bounceOut;
   animation-name: bounceOut;
+}
+
+
 }
 @-webkit-keyframes bounceOutDown {
   20% {


### PR DESCRIPTION
It appears that there are duplicated property names in the CSS code you've provided. In CSS, when you have multiple declarations for the same property within the same selector, the last declaration will override the previous ones. Therefore, setting a default value for a property would involve either removing the duplicates or ensuring that the desired default value is the last declaration.

If you want to set a 
In this code, --animate-duration is defined with a default value of 1s in the :root pseudo-class. This ensures that the variable always has a value, but it can still be overridden or modified elsewhere in your CSS if needed.