### PR TITLE
Add DOM Style version of animate.css

### DIFF
--- a/animate-css.cjs
+++ b/animate-css.cjs
@@ -1,0 +1,1637 @@
+'use strict';
+
+function getDefaultExportFromCjs (x) {
+	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+}
+
+const bounce = (duration, iterations=1, easing="cubic-bezier(0.215, 0.61, 0.355, 1)") => {
+    return {
+        keyframes: [
+            { transform: 'translate3d(0, 0, 0)', offset: 0 },
+            { transform: 'translate3d(0, -30px, 0) scaleY(1.1)', offset: 0.4 },
+            { transform: 'translate3d(0, -15px, 0) scaleY(1.05)', offset: 0.7 },
+            { transform: 'translate3d(0, 0, 0) scaleY(0.95)', offset: 0.8 },
+            { transform: 'translate3d(0, -4px, 0) scaleY(1.02)', offset: 0.9 },
+            { transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const flash = (duration = 1000, iterations = Infinity, easing = 'linear') => {
+    return {
+        keyframes: [
+            { opacity: 1, offset: 0 },
+            { opacity: 0, offset: 0.25 },
+            { opacity: 1, offset: 0.5 },
+            { opacity: 0, offset: 0.75 },
+            { opacity: 1, offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const headShake = (duration = 1000, iterations = 1, easing = 'ease-in-out') => {
+    return {
+        keyframes: [
+            { transform: 'translateX(0) rotateY(0deg)', offset: 0 },
+            { transform: 'translateX(-6px) rotateY(-9deg)', offset: 0.065 },
+            { transform: 'translateX(5px) rotateY(7deg)', offset: 0.185 },
+            { transform: 'translateX(-3px) rotateY(-5deg)', offset: 0.315 },
+            { transform: 'translateX(2px) rotateY(3deg)', offset: 0.435 },
+            { transform: 'translateX(0) rotateY(0deg)', offset: 0.5 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const heartBeat = (duration = 1000,iterations = Infinity, easing = 'ease-in-out') => {
+    return {
+        keyframes: [
+            { transform: 'scale(1)', offset: 0 },
+            { transform: 'scale(1.3)', offset: 0.14 },
+            { transform: 'scale(1)', offset: 0.28 },
+            { transform: 'scale(1.3)', offset: 0.42 },
+            { transform: 'scale(1)', offset: 0.7 }
+        ],
+        config: {
+            duration: duration * 1.3,  // To Fix
+            easing,
+            iterations 
+        }
+    };
+};
+const jello = (duration = 1000,iterations = Infinity, easing = 'ease-in-out') => {
+    return {
+        keyframes: [
+            { transform: 'translate3d(0, 0, 0)', offset: 0 },
+            { transform: 'skewX(-12.5deg) skewY(-12.5deg)', offset: 0.222 },
+            { transform: 'skewX(6.25deg) skewY(6.25deg)', offset: 0.333 },
+            { transform: 'skewX(-3.125deg) skewY(-3.125deg)', offset: 0.444 },
+            { transform: 'skewX(1.5625deg) skewY(1.5625deg)', offset: 0.555 },
+            { transform: 'skewX(-0.78125deg) skewY(-0.78125deg)', offset: 0.666 },
+            { transform: 'skewX(0.390625deg) skewY(0.390625deg)', offset: 0.777 },
+            { transform: 'skewX(-0.1953125deg) skewY(-0.1953125deg)', offset: 0.888 },
+            { transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const pulse = (duration = 1000,iterations = Infinity, easing = 'ease-in-out') => {
+    return {
+        keyframes: [
+            { transform: 'scale3d(1, 1, 1)', offset: 0 },
+            { transform: 'scale3d(1.05, 1.05, 1.05)', offset: 0.5 },
+            { transform: 'scale3d(1, 1, 1)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const rubberBand = (duration = 1000,iterations = 1, easing = 'ease-in-out') => {
+    return {
+        keyframes: [
+            { transform: 'scale3d(1, 1, 1)', offset: 0 },
+            { transform: 'scale3d(1.25, 0.75, 1)', offset: 0.30 },
+            { transform: 'scale3d(0.75, 1.25, 1)', offset: 0.40 },
+            { transform: 'scale3d(1.15, 0.85, 1)', offset: 0.50 },
+            { transform: 'scale3d(0.95, 1.05, 1)', offset: 0.65 },
+            { transform: 'scale3d(1.05, 0.95, 1)', offset: 0.75 },
+            { transform: 'scale3d(1, 1, 1)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const shake = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'translate3d(0, 0, 0)', offset: 0 },
+            { transform: 'translate3d(-10px, 0, 0)', offset: 0.10 },
+            { transform: 'translate3d(10px, 0, 0)', offset: 0.20 },
+            { transform: 'translate3d(-10px, 0, 0)', offset: 0.30 },
+            { transform: 'translate3d(10px, 0, 0)', offset: 0.40 },
+            { transform: 'translate3d(-10px, 0, 0)', offset: 0.50 },
+            { transform: 'translate3d(10px, 0, 0)', offset: 0.60 },
+            { transform: 'translate3d(-10px, 0, 0)', offset: 0.70 },
+            { transform: 'translate3d(10px, 0, 0)', offset: 0.80 },
+            { transform: 'translate3d(-10px, 0, 0)', offset: 0.90 },
+            { transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const shakeX = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'translate3d(0, 0, 0)', offset: 0 },
+            { transform: 'translate3d(-10px, 0, 0)', offset: 0.10 },
+            { transform: 'translate3d(10px, 0, 0)', offset: 0.20 },
+            { transform: 'translate3d(-10px, 0, 0)', offset: 0.30 },
+            { transform: 'translate3d(10px, 0, 0)', offset: 0.40 },
+            { transform: 'translate3d(-10px, 0, 0)', offset: 0.50 },
+            { transform: 'translate3d(10px, 0, 0)', offset: 0.60 },
+            { transform: 'translate3d(-10px, 0, 0)', offset: 0.70 },
+            { transform: 'translate3d(10px, 0, 0)', offset: 0.80 },
+            { transform: 'translate3d(-10px, 0, 0)', offset: 0.90 },
+            { transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const shakeY = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'translate3d(0, 0, 0)', offset: 0 },
+            { transform: 'translate3d(0, -10px, 0)', offset: 0.10 },
+            { transform: 'translate3d(0, 10px, 0)', offset: 0.20 },
+            { transform: 'translate3d(0, -10px, 0)', offset: 0.30 },
+            { transform: 'translate3d(0, 10px, 0)', offset: 0.40 },
+            { transform: 'translate3d(0, -10px, 0)', offset: 0.50 },
+            { transform: 'translate3d(0, 10px, 0)', offset: 0.60 },
+            { transform: 'translate3d(0, -10px, 0)', offset: 0.70 },
+            { transform: 'translate3d(0, 10px, 0)', offset: 0.80 },
+            { transform: 'translate3d(0, -10px, 0)', offset: 0.90 },
+            { transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const swing = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'rotate3d(0, 0, 1, 0deg)', offset: 0 },  // Equivalent to `from`
+            { transform: 'rotate3d(0, 0, 1, 15deg)', offset: 0.20 },
+            { transform: 'rotate3d(0, 0, 1, -10deg)', offset: 0.40 },
+            { transform: 'rotate3d(0, 0, 1, 5deg)', offset: 0.60 },
+            { transform: 'rotate3d(0, 0, 1, -5deg)', offset: 0.80 },
+            { transform: 'rotate3d(0, 0, 1, 0deg)', offset: 1 }  // Equivalent to `to`
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const tada = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'scale3d(1, 1, 1)', offset: 0 },
+            { transform: 'scale3d(0.9, 0.9, 0.9) rotate3d(0, 0, 1, -3deg)', offset: 0.1 },
+            { transform: 'scale3d(0.9, 0.9, 0.9) rotate3d(0, 0, 1, -3deg)', offset: 0.2 },
+            { transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)', offset: 0.3 },
+            { transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg)', offset: 0.4 },
+            { transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)', offset: 0.5 },
+            { transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg)', offset: 0.6 },
+            { transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)', offset: 0.7 },
+            { transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg)', offset: 0.8 },
+            { transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)', offset: 0.9 },
+            { transform: 'scale3d(1, 1, 1)', offset: 1 } 
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const wobble = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'translate3d(0, 0, 0)', offset: 0 },  // Equivalent to `from`
+            { transform: 'translate3d(-25%, 0, 0) rotate3d(0, 0, 1, -5deg)', offset: 0.15 },
+            { transform: 'translate3d(20%, 0, 0) rotate3d(0, 0, 1, 3deg)', offset: 0.30 },
+            { transform: 'translate3d(-15%, 0, 0) rotate3d(0, 0, 1, -3deg)', offset: 0.45 },
+            { transform: 'translate3d(10%, 0, 0) rotate3d(0, 0, 1, 2deg)', offset: 0.60 },
+            { transform: 'translate3d(-5%, 0, 0) rotate3d(0, 0, 1, -1deg)', offset: 0.75 },
+            { transform: 'translate3d(0, 0, 0)', offset: 1 }  // Equivalent to `to`
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+var attentionSeekers={
+    bounce,
+    flash,
+    headShake,
+    heartBeat,
+    jello,
+    pulse,
+    rubberBand,
+    shake,
+    shakeX,
+    shakeY,
+    swing,
+    tada,
+    wobble
+};
+
+const backInDown = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'translateY(-1200px) scale(0.7)', opacity: 0.7, offset: 0 }, 
+            { transform: 'translateY(0px) scale(0.7)', opacity: 0.7, offset: 0.8 },   
+            { transform: 'scale(1)', opacity: 1, offset: 1 }                          
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const backInLeft = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'translateX(-2000px) scale(0.7)', opacity: 0.7, offset: 0 },  
+            { transform: 'translateX(0px) scale(0.7)', opacity: 0.7, offset: 0.8 },   
+            { transform: 'scale(1)', opacity: 1, offset: 1 }                         
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const backInRight = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'translateX(2000px) scale(0.7)', opacity: 0.7, offset: 0 },   
+            { transform: 'translateX(0px) scale(0.7)', opacity: 0.7, offset: 0.8 },    
+            { transform: 'scale(1)', opacity: 1, offset: 1 }                           
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const backInUp = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'translateY(1200px) scale(0.7)', opacity: 0.7, offset: 0 },   
+            { transform: 'translateY(0px) scale(0.7)', opacity: 0.7, offset: 0.8 },    
+            { transform: 'scale(1)', opacity: 1, offset: 1 }                           
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+var backIn={
+    backInDown,
+    backInLeft,
+    backInRight,
+    backInUp
+};
+
+const backOutDown = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'scale(1)', opacity: 1, offset: 0 },                          
+            { transform: 'translateY(0px) scale(0.7)', opacity: 0.7, offset: 0.2 },    
+            { transform: 'translateY(700px) scale(0.7)', opacity: 0.7, offset: 1 }     
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const backOutLeft = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'scale(1)', opacity: 1, offset: 0 },                            
+            { transform: 'translateX(0px) scale(0.7)', opacity: 0.7, offset: 0.2 },      
+            { transform: 'translateX(-2000px) scale(0.7)', opacity: 0.7, offset: 1 }     
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const backOutRight = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'scale(1)', opacity: 1, offset: 0 },                            
+            { transform: 'translateX(0px) scale(0.7)', opacity: 0.7, offset: 0.2 },      
+            { transform: 'translateX(2000px) scale(0.7)', opacity: 0.7, offset: 1 }      
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const backOutUp = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'scale(1)', opacity: 1, offset: 0 },                            
+            { transform: 'translateY(0px) scale(0.7)', opacity: 0.7, offset: 0.2 },      
+            { transform: 'translateY(-700px) scale(0.7)', opacity: 0.7, offset: 1 }      
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+var backOut={
+    backOutDown,
+    backOutLeft,
+    backOutRight,
+    backOutUp
+};
+
+const bounceIn = (duration = 1000, easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 0, transform: 'scale3d(0.3, 0.3, 0.3)', offset: 0 },                  
+            { transform: 'scale3d(1.1, 1.1, 1.1)', offset: 0.2 },                            
+            { transform: 'scale3d(0.9, 0.9, 0.9)', offset: 0.4 },                           
+            { opacity: 1, transform: 'scale3d(1.03, 1.03, 1.03)', offset: 0.6 },             
+            { transform: 'scale3d(0.97, 0.97, 0.97)', offset: 0.8 },                        
+            { opacity: 1, transform: 'scale3d(1, 1, 1)', offset: 1 }                       
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const bounceInDown = (duration = 1000, easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 0, transform: 'translate3d(0, -3000px, 0) scaleY(3)', offset: 0 },             
+            { opacity: 1, transform: 'translate3d(0, 25px, 0) scaleY(0.9)', offset: 0.6 },            
+            { transform: 'translate3d(0, -10px, 0) scaleY(0.95)', offset: 0.75 },                    
+            { transform: 'translate3d(0, 5px, 0) scaleY(0.985)', offset: 0.9 },                      
+            { transform: 'translate3d(0, 0, 0)', offset: 1 }                                         
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const bounceInLeft = (duration = 1000, easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 0, transform: 'translate3d(-3000px, 0, 0) scaleX(3)', offset: 0 },            
+            { opacity: 1, transform: 'translate3d(25px, 0, 0) scaleX(1)', offset: 0.6 },             
+            { transform: 'translate3d(-10px, 0, 0) scaleX(0.98)', offset: 0.75 },                  
+            { transform: 'translate3d(5px, 0, 0) scaleX(0.995)', offset: 0.9 },                    
+            { transform: 'translate3d(0, 0, 0)', offset: 1 }                                       
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const bounceInRight = (duration = 1000, easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 0, transform: 'translate3d(3000px, 0, 0) scaleX(3)', offset: 0 },            
+            { opacity: 1, transform: 'translate3d(-25px, 0, 0) scaleX(1)', offset: 0.6 },          
+            { transform: 'translate3d(10px, 0, 0) scaleX(0.98)', offset: 0.75 },                 
+            { transform: 'translate3d(-5px, 0, 0) scaleX(0.995)', offset: 0.9 },                 
+            { transform: 'translate3d(0, 0, 0)', offset: 1 }                                       
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const bounceInUp = (duration = 1000, easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 0, transform: 'translate3d(0, 3000px, 0) scaleY(5)', offset: 0 },          
+            { opacity: 1, transform: 'translate3d(0, -20px, 0) scaleY(0.9)', offset: 0.6 },      
+            { transform: 'translate3d(0, 10px, 0) scaleY(0.95)', offset: 0.75 },               
+            { transform: 'translate3d(0, -5px, 0) scaleY(0.985)', offset: 0.9 },              
+            { transform: 'translate3d(0, 0, 0)', offset: 1 }                                    
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+var bounceIn_1={
+    bounceIn,
+    bounceInDown,
+    bounceInLeft,
+    bounceInRight,
+    bounceInUp
+};
+
+const bounceOutDown = (duration = 1000, easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'translate3d(0, 10px, 0) scaleY(0.985)', offset: 0.2 },  
+            { opacity: 1, transform: 'translate3d(0, -20px, 0) scaleY(0.9)', offset: 0.45 }, 
+            { opacity: 0, transform: 'translate3d(0, 2000px, 0) scaleY(3)', offset: 1 }   
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const bounceOutLeft = (duration = 1000, easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 1, transform: 'translate3d(20px, 0, 0) scaleX(0.9)', offset: 0.2 },  
+            { opacity: 0, transform: 'translate3d(-2000px, 0, 0) scaleX(2)', offset: 1 }    
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const bounceOutRight = (duration = 1000, easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 1, transform: 'translate3d(-20px, 0, 0) scaleX(0.9)', offset: 0.2 },  
+            { opacity: 0, transform: 'translate3d(2000px, 0, 0) scaleX(2)', offset: 1 }    
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const bounceOutUp = (duration = 1000, easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'translate3d(0, -10px, 0) scaleY(0.985)', offset: 0.2 },  
+            { opacity: 1, transform: 'translate3d(0, 20px, 0) scaleY(0.9)', offset: 0.4 },  
+            { opacity: 1, transform: 'translate3d(0, 20px, 0) scaleY(0.9)', offset: 0.45 },  
+            { opacity: 0, transform: 'translate3d(0, -2000px, 0) scaleY(3)', offset: 1 }    
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+var bounceOut_1={
+    bounceOutDown,
+    bounceOutLeft,
+    bounceOutRight,
+    bounceOutUp
+};
+
+const fadeIn = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 0, offset: 0 },  
+            { opacity: 1, offset: 1 }   
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeInBottomLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 0, transform: 'translate3d(-100%, 100%, 0)', offset: 0 },
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeInBottomRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 0, transform: 'translate3d(100%, 100%, 0)', offset: 0 },
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeInDown = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 0, transform: 'translate3d(0, -100%, 0)', offset: 0 },
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeInDownBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 0, transform: 'translate3d(0, -2000px, 0)', offset: 0 },
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeInLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 0, transform: 'translate3d(-100%, 0, 0)', offset: 0 },
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeInLeftBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 0, transform: 'translate3d(-2000px, 0, 0)', offset: 0 },
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeInRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 0, transform: 'translate3d(100%, 0, 0)', offset: 0 },
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeInRightBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 0, transform: 'translate3d(2000px, 0, 0)', offset: 0 },
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeInTopLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 0, transform: 'translate3d(-100%, -100%, 0)', offset: 0 },
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeInTopRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 0, transform: 'translate3d(100%, -100%, 0)', offset: 0 },
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeInUp = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 0, transform: 'translate3d(0, 100%, 0)', offset: 0 },
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeInUpBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 0, transform: 'translate3d(0, 2000px, 0)', offset: 0 },
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+var fadeIn_1={
+    fadeIn,
+    fadeInBottomLeft,
+    fadeInBottomRight,
+    fadeInDown,
+    fadeInDownBig,
+    fadeInLeft,
+    fadeInLeftBig,
+    fadeInRight,
+    fadeInRightBig,
+    fadeInTopLeft,
+    fadeInTopRight,
+    fadeInUp,
+    fadeInUpBig
+};
+
+const fadeOut = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 1, offset: 0 },
+            { opacity: 0, offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeOutBottomLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0 },
+            { opacity: 0, transform: 'translate3d(-100%, 100%, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeOutBottomRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0 },
+            { opacity: 0, transform: 'translate3d(100%, 100%, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeOutDown = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0 },
+            { opacity: 0, transform: 'translate3d(0, 100%, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeOutDownBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0 },
+            { opacity: 0, transform: 'translate3d(0, 2000px, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeOutLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0 },
+            { opacity: 0, transform: 'translate3d(-100%, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeOutLeftBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0 },
+            { opacity: 0, transform: 'translate3d(-2000px, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeOutRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0 },
+            { opacity: 0, transform: 'translate3d(100%, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeOutRightBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0 },
+            { opacity: 0, transform: 'translate3d(2000px, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeOutTopLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0 },
+            { opacity: 0, transform: 'translate3d(-100%, -100%, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeOutTopRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0 },
+            { opacity: 0, transform: 'translate3d(100%, -100%, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeOutUp = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0 },
+            { opacity: 0, transform: 'translate3d(0, -100%, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const fadeOutUpBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0 },
+            { opacity: 0, transform: 'translate3d(0, -2000px, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+var fadeOut_1={
+    fadeOut,
+    fadeOutBottomLeft,
+    fadeOutBottomRight,
+    fadeOutDown,
+    fadeOutDownBig,
+    fadeOutLeft,
+    fadeOutLeftBig,
+    fadeOutRight,
+    fadeOutRightBig,
+    fadeOutTopLeft,
+    fadeOutTopRight,
+    fadeOutUp,
+    fadeOutUpBig
+};
+
+const flip = (duration = 1000, easing = 'ease-out', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 0) rotate3d(0, 1, 0, -360deg)', offset: 0, easing: 'ease-out' },
+            { transform: 'perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 150px) rotate3d(0, 1, 0, -190deg)', offset: 0.4, easing: 'ease-out' },
+            { transform: 'perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 150px) rotate3d(0, 1, 0, -170deg)', offset: 0.5, easing: 'ease-in' },
+            { transform: 'perspective(400px) scale3d(0.95, 0.95, 0.95) translate3d(0, 0, 0) rotate3d(0, 1, 0, 0deg)', offset: 0.8, easing: 'ease-in' },
+            { transform: 'perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 0) rotate3d(0, 1, 0, 0deg)', offset: 1, easing: 'ease-in' }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const flipInX = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'perspective(400px) rotate3d(1, 0, 0, 90deg)', opacity: 0, offset: 0, easing: 'ease-in' },
+            { transform: 'perspective(400px) rotate3d(1, 0, 0, -20deg)', offset: 0.4, easing: 'ease-in' },
+            { transform: 'perspective(400px) rotate3d(1, 0, 0, 10deg)', opacity: 1, offset: 0.6 },
+            { transform: 'perspective(400px) rotate3d(1, 0, 0, -5deg)', offset: 0.8 },
+            { transform: 'perspective(400px)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const flipInY = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'perspective(400px) rotate3d(0, 1, 0, 90deg)', opacity: 0, offset: 0, easing: 'ease-in' },
+            { transform: 'perspective(400px) rotate3d(0, 1, 0, -20deg)', offset: 0.4, easing: 'ease-in' },
+            { transform: 'perspective(400px) rotate3d(0, 1, 0, 10deg)', opacity: 1, offset: 0.6 },
+            { transform: 'perspective(400px) rotate3d(0, 1, 0, -5deg)', offset: 0.8 },
+            { transform: 'perspective(400px)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const flipOutX = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'perspective(400px)', offset: 0 },
+            { transform: 'perspective(400px) rotate3d(1, 0, 0, -20deg)', opacity: 1, offset: 0.3 },
+            { transform: 'perspective(400px) rotate3d(1, 0, 0, 90deg)', opacity: 0, offset: 1 }
+        ],
+        config: {
+            duration: duration * 0.75,
+            easing,
+            iterations
+        }
+    };
+};
+const flipOutY = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'perspective(400px)', offset: 0 },
+            { transform: 'perspective(400px) rotate3d(0, 1, 0, -15deg)', opacity: 1, offset: 0.3 },
+            { transform: 'perspective(400px) rotate3d(0, 1, 0, 90deg)', opacity: 0, offset: 1 }
+        ],
+        config: {
+            duration: duration * 0.75,
+            easing,
+            iterations
+        }
+    };
+};
+var flippers={
+    flip,
+    flipInX,
+    flipInY,
+    flipOutX,
+    flipOutY
+};
+
+const lightSpeedInLeft = (duration = 1000, easing = 'ease-out', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'translate3d(-100%, 0, 0) skewX(30deg)', opacity: 0, offset: 0 },
+            { transform: 'skewX(-20deg)', opacity: 1, offset: 0.6 },
+            { transform: 'skewX(5deg)', offset: 0.8 },
+            { transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const lightSpeedInRight = (duration = 1000, easing = 'ease-out', iterations = 1) => {
+    return {
+        keyframes: [
+            { transform: 'translate3d(100%, 0, 0) skewX(-30deg)', opacity: 0, offset: 0 },
+            { transform: 'skewX(20deg)', opacity: 1, offset: 0.6 },
+            { transform: 'skewX(-5deg)', offset: 0.8 },
+            { transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const lightSpeedOutLeft = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 1, offset: 0 },
+            { transform: 'translate3d(-100%, 0, 0) skewX(-30deg)', opacity: 0, offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const lightSpeedOutRight = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 1, offset: 0 },
+            { transform: 'translate3d(100%, 0, 0) skewX(30deg)', opacity: 0, offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+var lightspeed={
+    lightSpeedInLeft,
+    lightSpeedInRight,
+    lightSpeedOutLeft,
+    lightSpeedOutRight
+};
+
+const rotateIn = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { transform: 'rotate3d(0, 0, 1, -200deg)', opacity: 0, offset: 0 },
+            { transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const rotateInDownLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { transform: 'rotate3d(0, 0, 1, -45deg)', opacity: 0, offset: 0 },
+            { transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const rotateInDownRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { transform: 'rotate3d(0, 0, 1, 45deg)', opacity: 0, offset: 0 },
+            { transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const rotateInUpLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { transform: 'rotate3d(0, 0, 1, 45deg)', opacity: 0, offset: 0 },
+            { transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const rotateInUpRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { transform: 'rotate3d(0, 0, 1, -90deg)', opacity: 0, offset: 0 },
+            { transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+var rotateIn_1={
+    rotateIn,
+    rotateInDownLeft,
+    rotateInDownRight,
+    rotateInUpLeft,
+    rotateInUpRight
+};
+
+const rotateOut = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { opacity: 1, offset: 0 },
+            { transform: 'rotate3d(0, 0, 1, 200deg)', opacity: 0, offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const rotateOutDownLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { opacity: 1, offset: 0 },
+            { transform: 'rotate3d(0, 0, 1, 45deg)', opacity: 0, offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const rotateOutDownRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { opacity: 1, offset: 0 },
+            { transform: 'rotate3d(0, 0, 1, -45deg)', opacity: 0, offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const rotateOutUpLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { opacity: 1, offset: 0 },
+            { transform: 'rotate3d(0, 0, 1, -45deg)', opacity: 0, offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const rotateOutUpRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { opacity: 1, offset: 0 },
+            { transform: 'rotate3d(0, 0, 1, 90deg)', opacity: 0, offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+var rotateOut_1={
+    rotateOut,
+    rotateOutDownLeft,
+    rotateOutDownRight,
+    rotateOutUpLeft,
+    rotateOutUpRight
+};
+
+const slideInDown = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { transform: 'translate3d(0, -100%, 0)', visibility: 'visible', offset: 0 },
+            { transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const slideInLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { transform: 'translate3d(-100%, 0, 0)', visibility: 'visible', offset: 0 },
+            { transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const slideInRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { transform: 'translate3d(100%, 0, 0)', visibility: 'visible', offset: 0 },
+            { transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const slideInUp = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { transform: 'translate3d(0, 100%, 0)', visibility: 'visible', offset: 0 },
+            { transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+var slideIn={
+    slideInDown,
+    slideInLeft,
+    slideInRight,
+    slideInUp
+};
+
+const slideOutDown = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { transform: 'translate3d(0, 0, 0)', offset: 0 },
+            { visibility: 'hidden', transform: 'translate3d(0, 100%, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const slideOutLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { transform: 'translate3d(0, 0, 0)', offset: 0 },
+            { visibility: 'hidden', transform: 'translate3d(-100%, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const slideOutRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { transform: 'translate3d(0, 0, 0)', offset: 0 },
+            { visibility: 'hidden', transform: 'translate3d(100%, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const slideOutUp = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { transform: 'translate3d(0, 0, 0)', offset: 0 },
+            { visibility: 'hidden', transform: 'translate3d(0, -100%, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+var slideOut={
+    slideOutDown,
+    slideOutLeft,
+    slideOutRight,
+    slideOutUp
+};
+
+const hinge = (duration = 2000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+        keyframes: [
+            { offset: 0, animationTimingFunction: easing },
+            { transform: 'rotate3d(0, 0, 1, 80deg)', offset: 0.2, animationTimingFunction: easing },
+            { transform: 'rotate3d(0, 0, 1, 60deg)', offset: 0.4, opacity: 1, animationTimingFunction: easing },
+            { transform: 'rotate3d(0, 0, 1, 60deg)', offset: 0.6, opacity: 1, animationTimingFunction: easing },
+            { transform: 'rotate3d(0, 0, 1, 80deg)', offset: 0.8, animationTimingFunction: easing },
+            { transform: 'translate3d(0, 700px, 0)', opacity: 0, offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const jackInTheBox = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { opacity: 0, transform: 'scale(0.1) rotate(30deg)', transformOrigin: 'center bottom', offset: 0 },
+            { transform: 'rotate(-10deg)', offset: 0.5 },
+            { transform: 'rotate(3deg)', offset: 0.7 },
+            { opacity: 1, transform: 'scale(1)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const rollIn = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { opacity: 0, transform: 'translate3d(-100%, 0, 0) rotate3d(0, 0, 1, -120deg)', offset: 0 },
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const rollOut = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { opacity: 1, transform: 'translate3d(0, 0, 0) rotate3d(0, 0, 1, 0deg)', offset: 0 },
+            { opacity: 0, transform: 'translate3d(100%, 0, 0) rotate3d(0, 0, 1, 120deg)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+var specials={
+    hinge,
+    jackInTheBox,
+    rollIn,
+    rollOut
+};
+
+const zoomIn = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { opacity: 0, transform: 'scale3d(0.3, 0.3, 0.3)', offset: 0 },
+            { opacity: 1, transform: 'scale3d(1, 1, 1)', offset: 0.5 },
+            { opacity: 1, transform: 'scale3d(1, 1, 1)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const zoomInDown = (duration = 1000, easingIn = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)', easingOut = 'cubic-bezier(0.175, 0.885, 0.32, 1)', iterations = 1) => {
+    return {
+        keyframes: [
+            { 
+                opacity: 0,
+                transform: 'scale3d(0.1, 0.1, 0.1) translate3d(0, -1000px, 0)',
+                offset: 0,
+                easing: easingIn
+            },
+            { 
+                opacity: 1,
+                transform: 'scale3d(0.475, 0.475, 0.475) translate3d(0, 60px, 0)',
+                offset: 0.6,
+                easing: easingOut
+            },
+            { 
+                opacity: 1,
+                transform: 'scale3d(1, 1, 1) translate3d(0, 0, 0)',
+                offset: 1
+            }
+        ],
+        config: {
+            duration,
+            iterations
+        }
+    };
+};
+const zoomInLeft = (duration = 1000, easingIn = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)', easingOut = 'cubic-bezier(0.175, 0.885, 0.32, 1)', iterations = 1) => {
+    return {
+        keyframes: [
+            { 
+                opacity: 0,
+                transform: 'scale3d(0.1, 0.1, 0.1) translate3d(-1000px, 0, 0)',
+                offset: 0,
+                easing: easingIn
+            },
+            { 
+                opacity: 1,
+                transform: 'scale3d(0.475, 0.475, 0.475) translate3d(10px, 0, 0)',
+                offset: 0.6,
+                easing: easingOut
+            },
+            { 
+                opacity: 1,
+                transform: 'scale3d(1, 1, 1) translate3d(0, 0, 0)',
+                offset: 1
+            }
+        ],
+        config: {
+            duration,
+            iterations
+        }
+    };
+};
+const zoomInRight = (duration = 1000, easingIn = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)', easingOut = 'cubic-bezier(0.175, 0.885, 0.32, 1)', iterations = 1) => {
+    return {
+        keyframes: [
+            { 
+                opacity: 0,
+                transform: 'scale3d(0.1, 0.1, 0.1) translate3d(1000px, 0, 0)',
+                offset: 0,
+                easing: easingIn
+            },
+            { 
+                opacity: 1,
+                transform: 'scale3d(0.475, 0.475, 0.475) translate3d(-10px, 0, 0)',
+                offset: 0.6,
+                easing: easingOut
+            },
+            { 
+                opacity: 1,
+                transform: 'scale3d(1, 1, 1) translate3d(0, 0, 0)',
+                offset: 1
+            }
+        ],
+        config: {
+            duration,
+            iterations
+        }
+    };
+};
+const zoomInUp = (duration = 1000, easingIn = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)', easingOut = 'cubic-bezier(0.175, 0.885, 0.32, 1)', iterations = 1) => {
+    return {
+        keyframes: [
+            { 
+                opacity: 0,
+                transform: 'scale3d(0.1, 0.1, 0.1) translate3d(0, 1000px, 0)',
+                offset: 0,
+                easing: easingIn
+            },
+            { 
+                opacity: 1,
+                transform: 'scale3d(0.475, 0.475, 0.475) translate3d(0, -60px, 0)',
+                offset: 0.6,
+                easing: easingOut
+            },
+            { 
+                opacity: 1,
+                transform: 'scale3d(1, 1, 1) translate3d(0, 0, 0)',
+                offset: 1
+            }
+        ],
+        config: {
+            duration,
+            iterations
+        }
+    };
+};
+var zoomIn_1={
+    zoomIn,
+    zoomInDown,
+    zoomInLeft,
+    zoomInRight,
+    zoomInUp
+};
+
+const zoomOut = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+        keyframes: [
+            { 
+                opacity: 1,
+                transform: 'scale3d(1, 1, 1)',
+                offset: 0
+            },
+            { 
+                opacity: 0,
+                transform: 'scale3d(0.3, 0.3, 0.3)',
+                offset: 0.5
+            },
+            { 
+                opacity: 0,
+                transform: 'scale3d(0.3, 0.3, 0.3)',
+                offset: 1
+            }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        }
+    };
+};
+const zoomOutDown = (duration = 1000, iterations = 1, easingIn = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)', easingOut = 'cubic-bezier(0.175, 0.885, 0.32, 1)') => {
+    return {
+        keyframes: [
+            { 
+                opacity: 1,
+                transform: 'scale3d(0.475, 0.475, 0.475) translate3d(0, -60px, 0)',
+                offset: 0.4,
+                easing: easingIn
+            },
+            { 
+                opacity: 0,
+                transform: 'scale3d(0.1, 0.1, 0.1) translate3d(0, 2000px, 0)',
+                offset: 1,
+                easing: easingOut
+            }
+        ],
+        config: {
+            duration,
+            iterations
+        }
+    };
+};
+const zoomOutLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 1, transform: 'scale3d(0.475, 0.475, 0.475) translate3d(42px, 0, 0)', offset: 0.4 },
+            { opacity: 0, transform: 'scale(0.1) translate3d(-2000px, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        },
+        transformOrigin: 'left center'
+    };
+};
+const zoomOutRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+        keyframes: [
+            { opacity: 1, transform: 'scale3d(0.475, 0.475, 0.475) translate3d(-42px, 0, 0)', offset: 0.4 },
+            { opacity: 0, transform: 'scale(0.1) translate3d(2000px, 0, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        },
+        transformOrigin: 'right center'
+    };
+};
+const zoomOutUp = (duration = 1000, iterations = 1, easing = 'linear',) => {
+    return {
+        keyframes: [
+            { opacity: 1, transform: 'scale3d(0.475, 0.475, 0.475) translate3d(0, 60px, 0)', offset: 0.4 },
+            { opacity: 0, transform: 'scale3d(0.1, 0.1, 0.1) translate3d(0, -2000px, 0)', offset: 1 }
+        ],
+        config: {
+            duration,
+            easing,
+            iterations
+        },
+        transformOrigin: 'center bottom',
+        timingFunction: ['cubic-bezier(0.55, 0.055, 0.675, 0.19)', 'cubic-bezier(0.175, 0.885, 0.32, 1)']
+    };
+};
+var zoomOut_1={
+    zoomOut,
+    zoomOutDown,
+    zoomOutLeft,
+    zoomOutRight,
+    zoomOutUp
+};
+
+var js = {
+    ...attentionSeekers,
+    ...backIn,
+    ...backOut,
+    ...bounceIn_1,
+    ...bounceOut_1,
+    ...fadeIn_1,
+    ...fadeOut_1,
+    ...flippers,
+    ...lightspeed,
+    ...rotateIn_1,
+    ...rotateOut_1,
+    ...slideIn,
+    ...slideOut,
+    ...specials,
+    ...zoomIn_1,
+    ...zoomOut_1
+  };
+
+var index = /*@__PURE__*/getDefaultExportFromCjs(js);
+
+module.exports = index;

--- a/animate-css.js
+++ b/animate-css.js
@@ -1,0 +1,1774 @@
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined'
+    ? (module.exports = factory())
+    : typeof define === 'function' && define.amd
+    ? define(factory)
+    : ((global = typeof globalThis !== 'undefined' ? globalThis : global || self),
+      (global.AnimateCss = factory()));
+})(this, function () {
+  'use strict';
+
+  function getDefaultExportFromCjs(x) {
+    return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default')
+      ? x['default']
+      : x;
+  }
+
+  const bounce = (duration, iterations = 1, easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)') => {
+    return {
+      keyframes: [
+        {transform: 'translate3d(0, 0, 0)', offset: 0},
+        {transform: 'translate3d(0, -30px, 0) scaleY(1.1)', offset: 0.4},
+        {transform: 'translate3d(0, -15px, 0) scaleY(1.05)', offset: 0.7},
+        {transform: 'translate3d(0, 0, 0) scaleY(0.95)', offset: 0.8},
+        {transform: 'translate3d(0, -4px, 0) scaleY(1.02)', offset: 0.9},
+        {transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const flash = (duration = 1000, iterations = Infinity, easing = 'linear') => {
+    return {
+      keyframes: [
+        {opacity: 1, offset: 0},
+        {opacity: 0, offset: 0.25},
+        {opacity: 1, offset: 0.5},
+        {opacity: 0, offset: 0.75},
+        {opacity: 1, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const headShake = (duration = 1000, iterations = 1, easing = 'ease-in-out') => {
+    return {
+      keyframes: [
+        {transform: 'translateX(0) rotateY(0deg)', offset: 0},
+        {transform: 'translateX(-6px) rotateY(-9deg)', offset: 0.065},
+        {transform: 'translateX(5px) rotateY(7deg)', offset: 0.185},
+        {transform: 'translateX(-3px) rotateY(-5deg)', offset: 0.315},
+        {transform: 'translateX(2px) rotateY(3deg)', offset: 0.435},
+        {transform: 'translateX(0) rotateY(0deg)', offset: 0.5},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const heartBeat = (duration = 1000, iterations = Infinity, easing = 'ease-in-out') => {
+    return {
+      keyframes: [
+        {transform: 'scale(1)', offset: 0},
+        {transform: 'scale(1.3)', offset: 0.14},
+        {transform: 'scale(1)', offset: 0.28},
+        {transform: 'scale(1.3)', offset: 0.42},
+        {transform: 'scale(1)', offset: 0.7},
+      ],
+      config: {
+        duration: duration * 1.3, // To Fix
+        easing,
+        iterations,
+      },
+    };
+  };
+  const jello = (duration = 1000, iterations = Infinity, easing = 'ease-in-out') => {
+    return {
+      keyframes: [
+        {transform: 'translate3d(0, 0, 0)', offset: 0},
+        {transform: 'skewX(-12.5deg) skewY(-12.5deg)', offset: 0.222},
+        {transform: 'skewX(6.25deg) skewY(6.25deg)', offset: 0.333},
+        {transform: 'skewX(-3.125deg) skewY(-3.125deg)', offset: 0.444},
+        {transform: 'skewX(1.5625deg) skewY(1.5625deg)', offset: 0.555},
+        {transform: 'skewX(-0.78125deg) skewY(-0.78125deg)', offset: 0.666},
+        {transform: 'skewX(0.390625deg) skewY(0.390625deg)', offset: 0.777},
+        {transform: 'skewX(-0.1953125deg) skewY(-0.1953125deg)', offset: 0.888},
+        {transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const pulse = (duration = 1000, iterations = Infinity, easing = 'ease-in-out') => {
+    return {
+      keyframes: [
+        {transform: 'scale3d(1, 1, 1)', offset: 0},
+        {transform: 'scale3d(1.05, 1.05, 1.05)', offset: 0.5},
+        {transform: 'scale3d(1, 1, 1)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const rubberBand = (duration = 1000, iterations = 1, easing = 'ease-in-out') => {
+    return {
+      keyframes: [
+        {transform: 'scale3d(1, 1, 1)', offset: 0},
+        {transform: 'scale3d(1.25, 0.75, 1)', offset: 0.3},
+        {transform: 'scale3d(0.75, 1.25, 1)', offset: 0.4},
+        {transform: 'scale3d(1.15, 0.85, 1)', offset: 0.5},
+        {transform: 'scale3d(0.95, 1.05, 1)', offset: 0.65},
+        {transform: 'scale3d(1.05, 0.95, 1)', offset: 0.75},
+        {transform: 'scale3d(1, 1, 1)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const shake = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+      keyframes: [
+        {transform: 'translate3d(0, 0, 0)', offset: 0},
+        {transform: 'translate3d(-10px, 0, 0)', offset: 0.1},
+        {transform: 'translate3d(10px, 0, 0)', offset: 0.2},
+        {transform: 'translate3d(-10px, 0, 0)', offset: 0.3},
+        {transform: 'translate3d(10px, 0, 0)', offset: 0.4},
+        {transform: 'translate3d(-10px, 0, 0)', offset: 0.5},
+        {transform: 'translate3d(10px, 0, 0)', offset: 0.6},
+        {transform: 'translate3d(-10px, 0, 0)', offset: 0.7},
+        {transform: 'translate3d(10px, 0, 0)', offset: 0.8},
+        {transform: 'translate3d(-10px, 0, 0)', offset: 0.9},
+        {transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const shakeX = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+      keyframes: [
+        {transform: 'translate3d(0, 0, 0)', offset: 0},
+        {transform: 'translate3d(-10px, 0, 0)', offset: 0.1},
+        {transform: 'translate3d(10px, 0, 0)', offset: 0.2},
+        {transform: 'translate3d(-10px, 0, 0)', offset: 0.3},
+        {transform: 'translate3d(10px, 0, 0)', offset: 0.4},
+        {transform: 'translate3d(-10px, 0, 0)', offset: 0.5},
+        {transform: 'translate3d(10px, 0, 0)', offset: 0.6},
+        {transform: 'translate3d(-10px, 0, 0)', offset: 0.7},
+        {transform: 'translate3d(10px, 0, 0)', offset: 0.8},
+        {transform: 'translate3d(-10px, 0, 0)', offset: 0.9},
+        {transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const shakeY = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+      keyframes: [
+        {transform: 'translate3d(0, 0, 0)', offset: 0},
+        {transform: 'translate3d(0, -10px, 0)', offset: 0.1},
+        {transform: 'translate3d(0, 10px, 0)', offset: 0.2},
+        {transform: 'translate3d(0, -10px, 0)', offset: 0.3},
+        {transform: 'translate3d(0, 10px, 0)', offset: 0.4},
+        {transform: 'translate3d(0, -10px, 0)', offset: 0.5},
+        {transform: 'translate3d(0, 10px, 0)', offset: 0.6},
+        {transform: 'translate3d(0, -10px, 0)', offset: 0.7},
+        {transform: 'translate3d(0, 10px, 0)', offset: 0.8},
+        {transform: 'translate3d(0, -10px, 0)', offset: 0.9},
+        {transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const swing = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+      keyframes: [
+        {transform: 'rotate3d(0, 0, 1, 0deg)', offset: 0}, // Equivalent to `from`
+        {transform: 'rotate3d(0, 0, 1, 15deg)', offset: 0.2},
+        {transform: 'rotate3d(0, 0, 1, -10deg)', offset: 0.4},
+        {transform: 'rotate3d(0, 0, 1, 5deg)', offset: 0.6},
+        {transform: 'rotate3d(0, 0, 1, -5deg)', offset: 0.8},
+        {transform: 'rotate3d(0, 0, 1, 0deg)', offset: 1}, // Equivalent to `to`
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const tada = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+      keyframes: [
+        {transform: 'scale3d(1, 1, 1)', offset: 0},
+        {transform: 'scale3d(0.9, 0.9, 0.9) rotate3d(0, 0, 1, -3deg)', offset: 0.1},
+        {transform: 'scale3d(0.9, 0.9, 0.9) rotate3d(0, 0, 1, -3deg)', offset: 0.2},
+        {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)', offset: 0.3},
+        {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg)', offset: 0.4},
+        {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)', offset: 0.5},
+        {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg)', offset: 0.6},
+        {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)', offset: 0.7},
+        {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg)', offset: 0.8},
+        {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)', offset: 0.9},
+        {transform: 'scale3d(1, 1, 1)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const wobble = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+      keyframes: [
+        {transform: 'translate3d(0, 0, 0)', offset: 0}, // Equivalent to `from`
+        {transform: 'translate3d(-25%, 0, 0) rotate3d(0, 0, 1, -5deg)', offset: 0.15},
+        {transform: 'translate3d(20%, 0, 0) rotate3d(0, 0, 1, 3deg)', offset: 0.3},
+        {transform: 'translate3d(-15%, 0, 0) rotate3d(0, 0, 1, -3deg)', offset: 0.45},
+        {transform: 'translate3d(10%, 0, 0) rotate3d(0, 0, 1, 2deg)', offset: 0.6},
+        {transform: 'translate3d(-5%, 0, 0) rotate3d(0, 0, 1, -1deg)', offset: 0.75},
+        {transform: 'translate3d(0, 0, 0)', offset: 1}, // Equivalent to `to`
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  var attentionSeekers = {
+    bounce,
+    flash,
+    headShake,
+    heartBeat,
+    jello,
+    pulse,
+    rubberBand,
+    shake,
+    shakeX,
+    shakeY,
+    swing,
+    tada,
+    wobble,
+  };
+
+  const backInDown = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+      keyframes: [
+        {transform: 'translateY(-1200px) scale(0.7)', opacity: 0.7, offset: 0},
+        {transform: 'translateY(0px) scale(0.7)', opacity: 0.7, offset: 0.8},
+        {transform: 'scale(1)', opacity: 1, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const backInLeft = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+      keyframes: [
+        {transform: 'translateX(-2000px) scale(0.7)', opacity: 0.7, offset: 0},
+        {transform: 'translateX(0px) scale(0.7)', opacity: 0.7, offset: 0.8},
+        {transform: 'scale(1)', opacity: 1, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const backInRight = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+      keyframes: [
+        {transform: 'translateX(2000px) scale(0.7)', opacity: 0.7, offset: 0},
+        {transform: 'translateX(0px) scale(0.7)', opacity: 0.7, offset: 0.8},
+        {transform: 'scale(1)', opacity: 1, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const backInUp = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+      keyframes: [
+        {transform: 'translateY(1200px) scale(0.7)', opacity: 0.7, offset: 0},
+        {transform: 'translateY(0px) scale(0.7)', opacity: 0.7, offset: 0.8},
+        {transform: 'scale(1)', opacity: 1, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  var backIn = {
+    backInDown,
+    backInLeft,
+    backInRight,
+    backInUp,
+  };
+
+  const backOutDown = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+      keyframes: [
+        {transform: 'scale(1)', opacity: 1, offset: 0},
+        {transform: 'translateY(0px) scale(0.7)', opacity: 0.7, offset: 0.2},
+        {transform: 'translateY(700px) scale(0.7)', opacity: 0.7, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const backOutLeft = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+      keyframes: [
+        {transform: 'scale(1)', opacity: 1, offset: 0},
+        {transform: 'translateX(0px) scale(0.7)', opacity: 0.7, offset: 0.2},
+        {transform: 'translateX(-2000px) scale(0.7)', opacity: 0.7, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const backOutRight = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+      keyframes: [
+        {transform: 'scale(1)', opacity: 1, offset: 0},
+        {transform: 'translateX(0px) scale(0.7)', opacity: 0.7, offset: 0.2},
+        {transform: 'translateX(2000px) scale(0.7)', opacity: 0.7, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const backOutUp = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+      keyframes: [
+        {transform: 'scale(1)', opacity: 1, offset: 0},
+        {transform: 'translateY(0px) scale(0.7)', opacity: 0.7, offset: 0.2},
+        {transform: 'translateY(-700px) scale(0.7)', opacity: 0.7, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  var backOut = {
+    backOutDown,
+    backOutLeft,
+    backOutRight,
+    backOutUp,
+  };
+
+  const bounceIn = (
+    duration = 1000,
+    easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+    iterations = 1,
+  ) => {
+    return {
+      keyframes: [
+        {opacity: 0, transform: 'scale3d(0.3, 0.3, 0.3)', offset: 0},
+        {transform: 'scale3d(1.1, 1.1, 1.1)', offset: 0.2},
+        {transform: 'scale3d(0.9, 0.9, 0.9)', offset: 0.4},
+        {opacity: 1, transform: 'scale3d(1.03, 1.03, 1.03)', offset: 0.6},
+        {transform: 'scale3d(0.97, 0.97, 0.97)', offset: 0.8},
+        {opacity: 1, transform: 'scale3d(1, 1, 1)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const bounceInDown = (
+    duration = 1000,
+    easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+    iterations = 1,
+  ) => {
+    return {
+      keyframes: [
+        {opacity: 0, transform: 'translate3d(0, -3000px, 0) scaleY(3)', offset: 0},
+        {opacity: 1, transform: 'translate3d(0, 25px, 0) scaleY(0.9)', offset: 0.6},
+        {transform: 'translate3d(0, -10px, 0) scaleY(0.95)', offset: 0.75},
+        {transform: 'translate3d(0, 5px, 0) scaleY(0.985)', offset: 0.9},
+        {transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const bounceInLeft = (
+    duration = 1000,
+    easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+    iterations = 1,
+  ) => {
+    return {
+      keyframes: [
+        {opacity: 0, transform: 'translate3d(-3000px, 0, 0) scaleX(3)', offset: 0},
+        {opacity: 1, transform: 'translate3d(25px, 0, 0) scaleX(1)', offset: 0.6},
+        {transform: 'translate3d(-10px, 0, 0) scaleX(0.98)', offset: 0.75},
+        {transform: 'translate3d(5px, 0, 0) scaleX(0.995)', offset: 0.9},
+        {transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const bounceInRight = (
+    duration = 1000,
+    easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+    iterations = 1,
+  ) => {
+    return {
+      keyframes: [
+        {opacity: 0, transform: 'translate3d(3000px, 0, 0) scaleX(3)', offset: 0},
+        {opacity: 1, transform: 'translate3d(-25px, 0, 0) scaleX(1)', offset: 0.6},
+        {transform: 'translate3d(10px, 0, 0) scaleX(0.98)', offset: 0.75},
+        {transform: 'translate3d(-5px, 0, 0) scaleX(0.995)', offset: 0.9},
+        {transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const bounceInUp = (
+    duration = 1000,
+    easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+    iterations = 1,
+  ) => {
+    return {
+      keyframes: [
+        {opacity: 0, transform: 'translate3d(0, 3000px, 0) scaleY(5)', offset: 0},
+        {opacity: 1, transform: 'translate3d(0, -20px, 0) scaleY(0.9)', offset: 0.6},
+        {transform: 'translate3d(0, 10px, 0) scaleY(0.95)', offset: 0.75},
+        {transform: 'translate3d(0, -5px, 0) scaleY(0.985)', offset: 0.9},
+        {transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  var bounceIn_1 = {
+    bounceIn,
+    bounceInDown,
+    bounceInLeft,
+    bounceInRight,
+    bounceInUp,
+  };
+
+  const bounceOutDown = (
+    duration = 1000,
+    easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+    iterations = 1,
+  ) => {
+    return {
+      keyframes: [
+        {transform: 'translate3d(0, 10px, 0) scaleY(0.985)', offset: 0.2},
+        {opacity: 1, transform: 'translate3d(0, -20px, 0) scaleY(0.9)', offset: 0.45},
+        {opacity: 0, transform: 'translate3d(0, 2000px, 0) scaleY(3)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const bounceOutLeft = (
+    duration = 1000,
+    easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+    iterations = 1,
+  ) => {
+    return {
+      keyframes: [
+        {opacity: 1, transform: 'translate3d(20px, 0, 0) scaleX(0.9)', offset: 0.2},
+        {opacity: 0, transform: 'translate3d(-2000px, 0, 0) scaleX(2)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const bounceOutRight = (
+    duration = 1000,
+    easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+    iterations = 1,
+  ) => {
+    return {
+      keyframes: [
+        {opacity: 1, transform: 'translate3d(-20px, 0, 0) scaleX(0.9)', offset: 0.2},
+        {opacity: 0, transform: 'translate3d(2000px, 0, 0) scaleX(2)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const bounceOutUp = (
+    duration = 1000,
+    easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+    iterations = 1,
+  ) => {
+    return {
+      keyframes: [
+        {transform: 'translate3d(0, -10px, 0) scaleY(0.985)', offset: 0.2},
+        {opacity: 1, transform: 'translate3d(0, 20px, 0) scaleY(0.9)', offset: 0.4},
+        {opacity: 1, transform: 'translate3d(0, 20px, 0) scaleY(0.9)', offset: 0.45},
+        {opacity: 0, transform: 'translate3d(0, -2000px, 0) scaleY(3)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  var bounceOut_1 = {
+    bounceOutDown,
+    bounceOutLeft,
+    bounceOutRight,
+    bounceOutUp,
+  };
+
+  const fadeIn = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 0, offset: 0},
+        {opacity: 1, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeInBottomLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 0, transform: 'translate3d(-100%, 100%, 0)', offset: 0},
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeInBottomRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 0, transform: 'translate3d(100%, 100%, 0)', offset: 0},
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeInDown = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 0, transform: 'translate3d(0, -100%, 0)', offset: 0},
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeInDownBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 0, transform: 'translate3d(0, -2000px, 0)', offset: 0},
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeInLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 0, transform: 'translate3d(-100%, 0, 0)', offset: 0},
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeInLeftBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 0, transform: 'translate3d(-2000px, 0, 0)', offset: 0},
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeInRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 0, transform: 'translate3d(100%, 0, 0)', offset: 0},
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeInRightBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 0, transform: 'translate3d(2000px, 0, 0)', offset: 0},
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeInTopLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 0, transform: 'translate3d(-100%, -100%, 0)', offset: 0},
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeInTopRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 0, transform: 'translate3d(100%, -100%, 0)', offset: 0},
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeInUp = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 0, transform: 'translate3d(0, 100%, 0)', offset: 0},
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeInUpBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 0, transform: 'translate3d(0, 2000px, 0)', offset: 0},
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  var fadeIn_1 = {
+    fadeIn,
+    fadeInBottomLeft,
+    fadeInBottomRight,
+    fadeInDown,
+    fadeInDownBig,
+    fadeInLeft,
+    fadeInLeftBig,
+    fadeInRight,
+    fadeInRightBig,
+    fadeInTopLeft,
+    fadeInTopRight,
+    fadeInUp,
+    fadeInUpBig,
+  };
+
+  const fadeOut = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 1, offset: 0},
+        {opacity: 0, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeOutBottomLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+        {opacity: 0, transform: 'translate3d(-100%, 100%, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeOutBottomRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+        {opacity: 0, transform: 'translate3d(100%, 100%, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeOutDown = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+        {opacity: 0, transform: 'translate3d(0, 100%, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeOutDownBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+        {opacity: 0, transform: 'translate3d(0, 2000px, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeOutLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+        {opacity: 0, transform: 'translate3d(-100%, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeOutLeftBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+        {opacity: 0, transform: 'translate3d(-2000px, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeOutRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+        {opacity: 0, transform: 'translate3d(100%, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeOutRightBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+        {opacity: 0, transform: 'translate3d(2000px, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeOutTopLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+        {opacity: 0, transform: 'translate3d(-100%, -100%, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeOutTopRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+        {opacity: 0, transform: 'translate3d(100%, -100%, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeOutUp = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+        {opacity: 0, transform: 'translate3d(0, -100%, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const fadeOutUpBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+        {opacity: 0, transform: 'translate3d(0, -2000px, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  var fadeOut_1 = {
+    fadeOut,
+    fadeOutBottomLeft,
+    fadeOutBottomRight,
+    fadeOutDown,
+    fadeOutDownBig,
+    fadeOutLeft,
+    fadeOutLeftBig,
+    fadeOutRight,
+    fadeOutRightBig,
+    fadeOutTopLeft,
+    fadeOutTopRight,
+    fadeOutUp,
+    fadeOutUpBig,
+  };
+
+  const flip = (duration = 1000, easing = 'ease-out', iterations = 1) => {
+    return {
+      keyframes: [
+        {
+          transform:
+            'perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 0) rotate3d(0, 1, 0, -360deg)',
+          offset: 0,
+          easing: 'ease-out',
+        },
+        {
+          transform:
+            'perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 150px) rotate3d(0, 1, 0, -190deg)',
+          offset: 0.4,
+          easing: 'ease-out',
+        },
+        {
+          transform:
+            'perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 150px) rotate3d(0, 1, 0, -170deg)',
+          offset: 0.5,
+          easing: 'ease-in',
+        },
+        {
+          transform:
+            'perspective(400px) scale3d(0.95, 0.95, 0.95) translate3d(0, 0, 0) rotate3d(0, 1, 0, 0deg)',
+          offset: 0.8,
+          easing: 'ease-in',
+        },
+        {
+          transform:
+            'perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 0) rotate3d(0, 1, 0, 0deg)',
+          offset: 1,
+          easing: 'ease-in',
+        },
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const flipInX = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+    return {
+      keyframes: [
+        {
+          transform: 'perspective(400px) rotate3d(1, 0, 0, 90deg)',
+          opacity: 0,
+          offset: 0,
+          easing: 'ease-in',
+        },
+        {transform: 'perspective(400px) rotate3d(1, 0, 0, -20deg)', offset: 0.4, easing: 'ease-in'},
+        {transform: 'perspective(400px) rotate3d(1, 0, 0, 10deg)', opacity: 1, offset: 0.6},
+        {transform: 'perspective(400px) rotate3d(1, 0, 0, -5deg)', offset: 0.8},
+        {transform: 'perspective(400px)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const flipInY = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+    return {
+      keyframes: [
+        {
+          transform: 'perspective(400px) rotate3d(0, 1, 0, 90deg)',
+          opacity: 0,
+          offset: 0,
+          easing: 'ease-in',
+        },
+        {transform: 'perspective(400px) rotate3d(0, 1, 0, -20deg)', offset: 0.4, easing: 'ease-in'},
+        {transform: 'perspective(400px) rotate3d(0, 1, 0, 10deg)', opacity: 1, offset: 0.6},
+        {transform: 'perspective(400px) rotate3d(0, 1, 0, -5deg)', offset: 0.8},
+        {transform: 'perspective(400px)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const flipOutX = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+    return {
+      keyframes: [
+        {transform: 'perspective(400px)', offset: 0},
+        {transform: 'perspective(400px) rotate3d(1, 0, 0, -20deg)', opacity: 1, offset: 0.3},
+        {transform: 'perspective(400px) rotate3d(1, 0, 0, 90deg)', opacity: 0, offset: 1},
+      ],
+      config: {
+        duration: duration * 0.75,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const flipOutY = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+    return {
+      keyframes: [
+        {transform: 'perspective(400px)', offset: 0},
+        {transform: 'perspective(400px) rotate3d(0, 1, 0, -15deg)', opacity: 1, offset: 0.3},
+        {transform: 'perspective(400px) rotate3d(0, 1, 0, 90deg)', opacity: 0, offset: 1},
+      ],
+      config: {
+        duration: duration * 0.75,
+        easing,
+        iterations,
+      },
+    };
+  };
+  var flippers = {
+    flip,
+    flipInX,
+    flipInY,
+    flipOutX,
+    flipOutY,
+  };
+
+  const lightSpeedInLeft = (duration = 1000, easing = 'ease-out', iterations = 1) => {
+    return {
+      keyframes: [
+        {transform: 'translate3d(-100%, 0, 0) skewX(30deg)', opacity: 0, offset: 0},
+        {transform: 'skewX(-20deg)', opacity: 1, offset: 0.6},
+        {transform: 'skewX(5deg)', offset: 0.8},
+        {transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const lightSpeedInRight = (duration = 1000, easing = 'ease-out', iterations = 1) => {
+    return {
+      keyframes: [
+        {transform: 'translate3d(100%, 0, 0) skewX(-30deg)', opacity: 0, offset: 0},
+        {transform: 'skewX(20deg)', opacity: 1, offset: 0.6},
+        {transform: 'skewX(-5deg)', offset: 0.8},
+        {transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const lightSpeedOutLeft = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 1, offset: 0},
+        {transform: 'translate3d(-100%, 0, 0) skewX(-30deg)', opacity: 0, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const lightSpeedOutRight = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+    return {
+      keyframes: [
+        {opacity: 1, offset: 0},
+        {transform: 'translate3d(100%, 0, 0) skewX(30deg)', opacity: 0, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  var lightspeed = {
+    lightSpeedInLeft,
+    lightSpeedInRight,
+    lightSpeedOutLeft,
+    lightSpeedOutRight,
+  };
+
+  const rotateIn = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {transform: 'rotate3d(0, 0, 1, -200deg)', opacity: 0, offset: 0},
+        {transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const rotateInDownLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {transform: 'rotate3d(0, 0, 1, -45deg)', opacity: 0, offset: 0},
+        {transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const rotateInDownRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {transform: 'rotate3d(0, 0, 1, 45deg)', opacity: 0, offset: 0},
+        {transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const rotateInUpLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {transform: 'rotate3d(0, 0, 1, 45deg)', opacity: 0, offset: 0},
+        {transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const rotateInUpRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {transform: 'rotate3d(0, 0, 1, -90deg)', opacity: 0, offset: 0},
+        {transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  var rotateIn_1 = {
+    rotateIn,
+    rotateInDownLeft,
+    rotateInDownRight,
+    rotateInUpLeft,
+    rotateInUpRight,
+  };
+
+  const rotateOut = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {opacity: 1, offset: 0},
+        {transform: 'rotate3d(0, 0, 1, 200deg)', opacity: 0, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const rotateOutDownLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {opacity: 1, offset: 0},
+        {transform: 'rotate3d(0, 0, 1, 45deg)', opacity: 0, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const rotateOutDownRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {opacity: 1, offset: 0},
+        {transform: 'rotate3d(0, 0, 1, -45deg)', opacity: 0, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const rotateOutUpLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {opacity: 1, offset: 0},
+        {transform: 'rotate3d(0, 0, 1, -45deg)', opacity: 0, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const rotateOutUpRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {opacity: 1, offset: 0},
+        {transform: 'rotate3d(0, 0, 1, 90deg)', opacity: 0, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  var rotateOut_1 = {
+    rotateOut,
+    rotateOutDownLeft,
+    rotateOutDownRight,
+    rotateOutUpLeft,
+    rotateOutUpRight,
+  };
+
+  const slideInDown = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {transform: 'translate3d(0, -100%, 0)', visibility: 'visible', offset: 0},
+        {transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const slideInLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {transform: 'translate3d(-100%, 0, 0)', visibility: 'visible', offset: 0},
+        {transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const slideInRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {transform: 'translate3d(100%, 0, 0)', visibility: 'visible', offset: 0},
+        {transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const slideInUp = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {transform: 'translate3d(0, 100%, 0)', visibility: 'visible', offset: 0},
+        {transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  var slideIn = {
+    slideInDown,
+    slideInLeft,
+    slideInRight,
+    slideInUp,
+  };
+
+  const slideOutDown = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {transform: 'translate3d(0, 0, 0)', offset: 0},
+        {visibility: 'hidden', transform: 'translate3d(0, 100%, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const slideOutLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {transform: 'translate3d(0, 0, 0)', offset: 0},
+        {visibility: 'hidden', transform: 'translate3d(-100%, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const slideOutRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {transform: 'translate3d(0, 0, 0)', offset: 0},
+        {visibility: 'hidden', transform: 'translate3d(100%, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const slideOutUp = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {transform: 'translate3d(0, 0, 0)', offset: 0},
+        {visibility: 'hidden', transform: 'translate3d(0, -100%, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  var slideOut = {
+    slideOutDown,
+    slideOutLeft,
+    slideOutRight,
+    slideOutUp,
+  };
+
+  const hinge = (duration = 2000, easing = 'ease-in-out', iterations = 1) => {
+    return {
+      keyframes: [
+        {offset: 0, animationTimingFunction: easing},
+        {transform: 'rotate3d(0, 0, 1, 80deg)', offset: 0.2, animationTimingFunction: easing},
+        {
+          transform: 'rotate3d(0, 0, 1, 60deg)',
+          offset: 0.4,
+          opacity: 1,
+          animationTimingFunction: easing,
+        },
+        {
+          transform: 'rotate3d(0, 0, 1, 60deg)',
+          offset: 0.6,
+          opacity: 1,
+          animationTimingFunction: easing,
+        },
+        {transform: 'rotate3d(0, 0, 1, 80deg)', offset: 0.8, animationTimingFunction: easing},
+        {transform: 'translate3d(0, 700px, 0)', opacity: 0, offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const jackInTheBox = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {
+          opacity: 0,
+          transform: 'scale(0.1) rotate(30deg)',
+          transformOrigin: 'center bottom',
+          offset: 0,
+        },
+        {transform: 'rotate(-10deg)', offset: 0.5},
+        {transform: 'rotate(3deg)', offset: 0.7},
+        {opacity: 1, transform: 'scale(1)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const rollIn = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {opacity: 0, transform: 'translate3d(-100%, 0, 0) rotate3d(0, 0, 1, -120deg)', offset: 0},
+        {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const rollOut = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {opacity: 1, transform: 'translate3d(0, 0, 0) rotate3d(0, 0, 1, 0deg)', offset: 0},
+        {opacity: 0, transform: 'translate3d(100%, 0, 0) rotate3d(0, 0, 1, 120deg)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  var specials = {
+    hinge,
+    jackInTheBox,
+    rollIn,
+    rollOut,
+  };
+
+  const zoomIn = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {opacity: 0, transform: 'scale3d(0.3, 0.3, 0.3)', offset: 0},
+        {opacity: 1, transform: 'scale3d(1, 1, 1)', offset: 0.5},
+        {opacity: 1, transform: 'scale3d(1, 1, 1)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const zoomInDown = (
+    duration = 1000,
+    easingIn = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+    easingOut = 'cubic-bezier(0.175, 0.885, 0.32, 1)',
+    iterations = 1,
+  ) => {
+    return {
+      keyframes: [
+        {
+          opacity: 0,
+          transform: 'scale3d(0.1, 0.1, 0.1) translate3d(0, -1000px, 0)',
+          offset: 0,
+          easing: easingIn,
+        },
+        {
+          opacity: 1,
+          transform: 'scale3d(0.475, 0.475, 0.475) translate3d(0, 60px, 0)',
+          offset: 0.6,
+          easing: easingOut,
+        },
+        {
+          opacity: 1,
+          transform: 'scale3d(1, 1, 1) translate3d(0, 0, 0)',
+          offset: 1,
+        },
+      ],
+      config: {
+        duration,
+        iterations,
+      },
+    };
+  };
+  const zoomInLeft = (
+    duration = 1000,
+    easingIn = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+    easingOut = 'cubic-bezier(0.175, 0.885, 0.32, 1)',
+    iterations = 1,
+  ) => {
+    return {
+      keyframes: [
+        {
+          opacity: 0,
+          transform: 'scale3d(0.1, 0.1, 0.1) translate3d(-1000px, 0, 0)',
+          offset: 0,
+          easing: easingIn,
+        },
+        {
+          opacity: 1,
+          transform: 'scale3d(0.475, 0.475, 0.475) translate3d(10px, 0, 0)',
+          offset: 0.6,
+          easing: easingOut,
+        },
+        {
+          opacity: 1,
+          transform: 'scale3d(1, 1, 1) translate3d(0, 0, 0)',
+          offset: 1,
+        },
+      ],
+      config: {
+        duration,
+        iterations,
+      },
+    };
+  };
+  const zoomInRight = (
+    duration = 1000,
+    easingIn = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+    easingOut = 'cubic-bezier(0.175, 0.885, 0.32, 1)',
+    iterations = 1,
+  ) => {
+    return {
+      keyframes: [
+        {
+          opacity: 0,
+          transform: 'scale3d(0.1, 0.1, 0.1) translate3d(1000px, 0, 0)',
+          offset: 0,
+          easing: easingIn,
+        },
+        {
+          opacity: 1,
+          transform: 'scale3d(0.475, 0.475, 0.475) translate3d(-10px, 0, 0)',
+          offset: 0.6,
+          easing: easingOut,
+        },
+        {
+          opacity: 1,
+          transform: 'scale3d(1, 1, 1) translate3d(0, 0, 0)',
+          offset: 1,
+        },
+      ],
+      config: {
+        duration,
+        iterations,
+      },
+    };
+  };
+  const zoomInUp = (
+    duration = 1000,
+    easingIn = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+    easingOut = 'cubic-bezier(0.175, 0.885, 0.32, 1)',
+    iterations = 1,
+  ) => {
+    return {
+      keyframes: [
+        {
+          opacity: 0,
+          transform: 'scale3d(0.1, 0.1, 0.1) translate3d(0, 1000px, 0)',
+          offset: 0,
+          easing: easingIn,
+        },
+        {
+          opacity: 1,
+          transform: 'scale3d(0.475, 0.475, 0.475) translate3d(0, -60px, 0)',
+          offset: 0.6,
+          easing: easingOut,
+        },
+        {
+          opacity: 1,
+          transform: 'scale3d(1, 1, 1) translate3d(0, 0, 0)',
+          offset: 1,
+        },
+      ],
+      config: {
+        duration,
+        iterations,
+      },
+    };
+  };
+  var zoomIn_1 = {
+    zoomIn,
+    zoomInDown,
+    zoomInLeft,
+    zoomInRight,
+    zoomInUp,
+  };
+
+  const zoomOut = (duration = 1000, iterations = 1, easing = 'ease') => {
+    return {
+      keyframes: [
+        {
+          opacity: 1,
+          transform: 'scale3d(1, 1, 1)',
+          offset: 0,
+        },
+        {
+          opacity: 0,
+          transform: 'scale3d(0.3, 0.3, 0.3)',
+          offset: 0.5,
+        },
+        {
+          opacity: 0,
+          transform: 'scale3d(0.3, 0.3, 0.3)',
+          offset: 1,
+        },
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+    };
+  };
+  const zoomOutDown = (
+    duration = 1000,
+    iterations = 1,
+    easingIn = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+    easingOut = 'cubic-bezier(0.175, 0.885, 0.32, 1)',
+  ) => {
+    return {
+      keyframes: [
+        {
+          opacity: 1,
+          transform: 'scale3d(0.475, 0.475, 0.475) translate3d(0, -60px, 0)',
+          offset: 0.4,
+          easing: easingIn,
+        },
+        {
+          opacity: 0,
+          transform: 'scale3d(0.1, 0.1, 0.1) translate3d(0, 2000px, 0)',
+          offset: 1,
+          easing: easingOut,
+        },
+      ],
+      config: {
+        duration,
+        iterations,
+      },
+    };
+  };
+  const zoomOutLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {
+          opacity: 1,
+          transform: 'scale3d(0.475, 0.475, 0.475) translate3d(42px, 0, 0)',
+          offset: 0.4,
+        },
+        {opacity: 0, transform: 'scale(0.1) translate3d(-2000px, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+      transformOrigin: 'left center',
+    };
+  };
+  const zoomOutRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+    return {
+      keyframes: [
+        {
+          opacity: 1,
+          transform: 'scale3d(0.475, 0.475, 0.475) translate3d(-42px, 0, 0)',
+          offset: 0.4,
+        },
+        {opacity: 0, transform: 'scale(0.1) translate3d(2000px, 0, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+      transformOrigin: 'right center',
+    };
+  };
+  const zoomOutUp = (duration = 1000, iterations = 1, easing = 'linear') => {
+    return {
+      keyframes: [
+        {
+          opacity: 1,
+          transform: 'scale3d(0.475, 0.475, 0.475) translate3d(0, 60px, 0)',
+          offset: 0.4,
+        },
+        {opacity: 0, transform: 'scale3d(0.1, 0.1, 0.1) translate3d(0, -2000px, 0)', offset: 1},
+      ],
+      config: {
+        duration,
+        easing,
+        iterations,
+      },
+      transformOrigin: 'center bottom',
+      timingFunction: [
+        'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+        'cubic-bezier(0.175, 0.885, 0.32, 1)',
+      ],
+    };
+  };
+  var zoomOut_1 = {
+    zoomOut,
+    zoomOutDown,
+    zoomOutLeft,
+    zoomOutRight,
+    zoomOutUp,
+  };
+
+  var js = {
+    ...attentionSeekers,
+    ...backIn,
+    ...backOut,
+    ...bounceIn_1,
+    ...bounceOut_1,
+    ...fadeIn_1,
+    ...fadeOut_1,
+    ...flippers,
+    ...lightspeed,
+    ...rotateIn_1,
+    ...rotateOut_1,
+    ...slideIn,
+    ...slideOut,
+    ...specials,
+    ...zoomIn_1,
+    ...zoomOut_1,
+  };
+
+  var index = /*@__PURE__*/ getDefaultExportFromCjs(js);
+
+  return index;
+});

--- a/animate-css.min.js
+++ b/animate-css.min.js
@@ -1,0 +1,1003 @@
+!(function (t, e) {
+  'object' == typeof exports && 'undefined' != typeof module
+    ? (module.exports = e())
+    : 'function' == typeof define && define.amd
+    ? define(e)
+    : ((t = 'undefined' != typeof globalThis ? globalThis : t || self).AnimateCss = e());
+})(this, function () {
+  'use strict';
+  function t(t) {
+    return t && t.__esModule && Object.prototype.hasOwnProperty.call(t, 'default') ? t.default : t;
+  }
+  return t({
+    ...{
+      bounce: (t, e = 1, a = 'cubic-bezier(0.215, 0.61, 0.355, 1)') => ({
+        keyframes: [
+          {transform: 'translate3d(0, 0, 0)', offset: 0},
+          {transform: 'translate3d(0, -30px, 0) scaleY(1.1)', offset: 0.4},
+          {transform: 'translate3d(0, -15px, 0) scaleY(1.05)', offset: 0.7},
+          {transform: 'translate3d(0, 0, 0) scaleY(0.95)', offset: 0.8},
+          {transform: 'translate3d(0, -4px, 0) scaleY(1.02)', offset: 0.9},
+          {transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      flash: (t = 1e3, e = 1 / 0, a = 'linear') => ({
+        keyframes: [
+          {opacity: 1, offset: 0},
+          {opacity: 0, offset: 0.25},
+          {opacity: 1, offset: 0.5},
+          {opacity: 0, offset: 0.75},
+          {opacity: 1, offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      headShake: (t = 1e3, e = 1, a = 'ease-in-out') => ({
+        keyframes: [
+          {transform: 'translateX(0) rotateY(0deg)', offset: 0},
+          {transform: 'translateX(-6px) rotateY(-9deg)', offset: 0.065},
+          {transform: 'translateX(5px) rotateY(7deg)', offset: 0.185},
+          {transform: 'translateX(-3px) rotateY(-5deg)', offset: 0.315},
+          {transform: 'translateX(2px) rotateY(3deg)', offset: 0.435},
+          {transform: 'translateX(0) rotateY(0deg)', offset: 0.5},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      heartBeat: (t = 1e3, e = 1 / 0, a = 'ease-in-out') => ({
+        keyframes: [
+          {transform: 'scale(1)', offset: 0},
+          {transform: 'scale(1.3)', offset: 0.14},
+          {transform: 'scale(1)', offset: 0.28},
+          {transform: 'scale(1.3)', offset: 0.42},
+          {transform: 'scale(1)', offset: 0.7},
+        ],
+        config: {duration: 1.3 * t, easing: a, iterations: e},
+      }),
+      jello: (t = 1e3, e = 1 / 0, a = 'ease-in-out') => ({
+        keyframes: [
+          {transform: 'translate3d(0, 0, 0)', offset: 0},
+          {transform: 'skewX(-12.5deg) skewY(-12.5deg)', offset: 0.222},
+          {transform: 'skewX(6.25deg) skewY(6.25deg)', offset: 0.333},
+          {transform: 'skewX(-3.125deg) skewY(-3.125deg)', offset: 0.444},
+          {transform: 'skewX(1.5625deg) skewY(1.5625deg)', offset: 0.555},
+          {transform: 'skewX(-0.78125deg) skewY(-0.78125deg)', offset: 0.666},
+          {transform: 'skewX(0.390625deg) skewY(0.390625deg)', offset: 0.777},
+          {transform: 'skewX(-0.1953125deg) skewY(-0.1953125deg)', offset: 0.888},
+          {transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      pulse: (t = 1e3, e = 1 / 0, a = 'ease-in-out') => ({
+        keyframes: [
+          {transform: 'scale3d(1, 1, 1)', offset: 0},
+          {transform: 'scale3d(1.05, 1.05, 1.05)', offset: 0.5},
+          {transform: 'scale3d(1, 1, 1)', offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      rubberBand: (t = 1e3, e = 1, a = 'ease-in-out') => ({
+        keyframes: [
+          {transform: 'scale3d(1, 1, 1)', offset: 0},
+          {transform: 'scale3d(1.25, 0.75, 1)', offset: 0.3},
+          {transform: 'scale3d(0.75, 1.25, 1)', offset: 0.4},
+          {transform: 'scale3d(1.15, 0.85, 1)', offset: 0.5},
+          {transform: 'scale3d(0.95, 1.05, 1)', offset: 0.65},
+          {transform: 'scale3d(1.05, 0.95, 1)', offset: 0.75},
+          {transform: 'scale3d(1, 1, 1)', offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      shake: (t = 1e3, e = 'ease-in-out', a = 1) => ({
+        keyframes: [
+          {transform: 'translate3d(0, 0, 0)', offset: 0},
+          {transform: 'translate3d(-10px, 0, 0)', offset: 0.1},
+          {transform: 'translate3d(10px, 0, 0)', offset: 0.2},
+          {transform: 'translate3d(-10px, 0, 0)', offset: 0.3},
+          {transform: 'translate3d(10px, 0, 0)', offset: 0.4},
+          {transform: 'translate3d(-10px, 0, 0)', offset: 0.5},
+          {transform: 'translate3d(10px, 0, 0)', offset: 0.6},
+          {transform: 'translate3d(-10px, 0, 0)', offset: 0.7},
+          {transform: 'translate3d(10px, 0, 0)', offset: 0.8},
+          {transform: 'translate3d(-10px, 0, 0)', offset: 0.9},
+          {transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      shakeX: (t = 1e3, e = 'ease-in-out', a = 1) => ({
+        keyframes: [
+          {transform: 'translate3d(0, 0, 0)', offset: 0},
+          {transform: 'translate3d(-10px, 0, 0)', offset: 0.1},
+          {transform: 'translate3d(10px, 0, 0)', offset: 0.2},
+          {transform: 'translate3d(-10px, 0, 0)', offset: 0.3},
+          {transform: 'translate3d(10px, 0, 0)', offset: 0.4},
+          {transform: 'translate3d(-10px, 0, 0)', offset: 0.5},
+          {transform: 'translate3d(10px, 0, 0)', offset: 0.6},
+          {transform: 'translate3d(-10px, 0, 0)', offset: 0.7},
+          {transform: 'translate3d(10px, 0, 0)', offset: 0.8},
+          {transform: 'translate3d(-10px, 0, 0)', offset: 0.9},
+          {transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      shakeY: (t = 1e3, e = 'ease-in-out', a = 1) => ({
+        keyframes: [
+          {transform: 'translate3d(0, 0, 0)', offset: 0},
+          {transform: 'translate3d(0, -10px, 0)', offset: 0.1},
+          {transform: 'translate3d(0, 10px, 0)', offset: 0.2},
+          {transform: 'translate3d(0, -10px, 0)', offset: 0.3},
+          {transform: 'translate3d(0, 10px, 0)', offset: 0.4},
+          {transform: 'translate3d(0, -10px, 0)', offset: 0.5},
+          {transform: 'translate3d(0, 10px, 0)', offset: 0.6},
+          {transform: 'translate3d(0, -10px, 0)', offset: 0.7},
+          {transform: 'translate3d(0, 10px, 0)', offset: 0.8},
+          {transform: 'translate3d(0, -10px, 0)', offset: 0.9},
+          {transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      swing: (t = 1e3, e = 'ease-in-out', a = 1) => ({
+        keyframes: [
+          {transform: 'rotate3d(0, 0, 1, 0deg)', offset: 0},
+          {transform: 'rotate3d(0, 0, 1, 15deg)', offset: 0.2},
+          {transform: 'rotate3d(0, 0, 1, -10deg)', offset: 0.4},
+          {transform: 'rotate3d(0, 0, 1, 5deg)', offset: 0.6},
+          {transform: 'rotate3d(0, 0, 1, -5deg)', offset: 0.8},
+          {transform: 'rotate3d(0, 0, 1, 0deg)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      tada: (t = 1e3, e = 'ease-in-out', a = 1) => ({
+        keyframes: [
+          {transform: 'scale3d(1, 1, 1)', offset: 0},
+          {transform: 'scale3d(0.9, 0.9, 0.9) rotate3d(0, 0, 1, -3deg)', offset: 0.1},
+          {transform: 'scale3d(0.9, 0.9, 0.9) rotate3d(0, 0, 1, -3deg)', offset: 0.2},
+          {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)', offset: 0.3},
+          {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg)', offset: 0.4},
+          {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)', offset: 0.5},
+          {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg)', offset: 0.6},
+          {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)', offset: 0.7},
+          {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg)', offset: 0.8},
+          {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)', offset: 0.9},
+          {transform: 'scale3d(1, 1, 1)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      wobble: (t = 1e3, e = 'ease-in-out', a = 1) => ({
+        keyframes: [
+          {transform: 'translate3d(0, 0, 0)', offset: 0},
+          {transform: 'translate3d(-25%, 0, 0) rotate3d(0, 0, 1, -5deg)', offset: 0.15},
+          {transform: 'translate3d(20%, 0, 0) rotate3d(0, 0, 1, 3deg)', offset: 0.3},
+          {transform: 'translate3d(-15%, 0, 0) rotate3d(0, 0, 1, -3deg)', offset: 0.45},
+          {transform: 'translate3d(10%, 0, 0) rotate3d(0, 0, 1, 2deg)', offset: 0.6},
+          {transform: 'translate3d(-5%, 0, 0) rotate3d(0, 0, 1, -1deg)', offset: 0.75},
+          {transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+    },
+    ...{
+      backInDown: (t = 1e3, e = 'ease-in-out', a = 1) => ({
+        keyframes: [
+          {transform: 'translateY(-1200px) scale(0.7)', opacity: 0.7, offset: 0},
+          {transform: 'translateY(0px) scale(0.7)', opacity: 0.7, offset: 0.8},
+          {transform: 'scale(1)', opacity: 1, offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      backInLeft: (t = 1e3, e = 'ease-in-out', a = 1) => ({
+        keyframes: [
+          {transform: 'translateX(-2000px) scale(0.7)', opacity: 0.7, offset: 0},
+          {transform: 'translateX(0px) scale(0.7)', opacity: 0.7, offset: 0.8},
+          {transform: 'scale(1)', opacity: 1, offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      backInRight: (t = 1e3, e = 'ease-in-out', a = 1) => ({
+        keyframes: [
+          {transform: 'translateX(2000px) scale(0.7)', opacity: 0.7, offset: 0},
+          {transform: 'translateX(0px) scale(0.7)', opacity: 0.7, offset: 0.8},
+          {transform: 'scale(1)', opacity: 1, offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      backInUp: (t = 1e3, e = 'ease-in-out', a = 1) => ({
+        keyframes: [
+          {transform: 'translateY(1200px) scale(0.7)', opacity: 0.7, offset: 0},
+          {transform: 'translateY(0px) scale(0.7)', opacity: 0.7, offset: 0.8},
+          {transform: 'scale(1)', opacity: 1, offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+    },
+    ...{
+      backOutDown: (t = 1e3, e = 'ease-in-out', a = 1) => ({
+        keyframes: [
+          {transform: 'scale(1)', opacity: 1, offset: 0},
+          {transform: 'translateY(0px) scale(0.7)', opacity: 0.7, offset: 0.2},
+          {transform: 'translateY(700px) scale(0.7)', opacity: 0.7, offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      backOutLeft: (t = 1e3, e = 'ease-in-out', a = 1) => ({
+        keyframes: [
+          {transform: 'scale(1)', opacity: 1, offset: 0},
+          {transform: 'translateX(0px) scale(0.7)', opacity: 0.7, offset: 0.2},
+          {transform: 'translateX(-2000px) scale(0.7)', opacity: 0.7, offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      backOutRight: (t = 1e3, e = 'ease-in-out', a = 1) => ({
+        keyframes: [
+          {transform: 'scale(1)', opacity: 1, offset: 0},
+          {transform: 'translateX(0px) scale(0.7)', opacity: 0.7, offset: 0.2},
+          {transform: 'translateX(2000px) scale(0.7)', opacity: 0.7, offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      backOutUp: (t = 1e3, e = 'ease-in-out', a = 1) => ({
+        keyframes: [
+          {transform: 'scale(1)', opacity: 1, offset: 0},
+          {transform: 'translateY(0px) scale(0.7)', opacity: 0.7, offset: 0.2},
+          {transform: 'translateY(-700px) scale(0.7)', opacity: 0.7, offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+    },
+    ...{
+      bounceIn: (t = 1e3, e = 'cubic-bezier(0.215, 0.61, 0.355, 1)', a = 1) => ({
+        keyframes: [
+          {opacity: 0, transform: 'scale3d(0.3, 0.3, 0.3)', offset: 0},
+          {transform: 'scale3d(1.1, 1.1, 1.1)', offset: 0.2},
+          {transform: 'scale3d(0.9, 0.9, 0.9)', offset: 0.4},
+          {opacity: 1, transform: 'scale3d(1.03, 1.03, 1.03)', offset: 0.6},
+          {transform: 'scale3d(0.97, 0.97, 0.97)', offset: 0.8},
+          {opacity: 1, transform: 'scale3d(1, 1, 1)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      bounceInDown: (t = 1e3, e = 'cubic-bezier(0.215, 0.61, 0.355, 1)', a = 1) => ({
+        keyframes: [
+          {opacity: 0, transform: 'translate3d(0, -3000px, 0) scaleY(3)', offset: 0},
+          {opacity: 1, transform: 'translate3d(0, 25px, 0) scaleY(0.9)', offset: 0.6},
+          {transform: 'translate3d(0, -10px, 0) scaleY(0.95)', offset: 0.75},
+          {transform: 'translate3d(0, 5px, 0) scaleY(0.985)', offset: 0.9},
+          {transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      bounceInLeft: (t = 1e3, e = 'cubic-bezier(0.215, 0.61, 0.355, 1)', a = 1) => ({
+        keyframes: [
+          {opacity: 0, transform: 'translate3d(-3000px, 0, 0) scaleX(3)', offset: 0},
+          {opacity: 1, transform: 'translate3d(25px, 0, 0) scaleX(1)', offset: 0.6},
+          {transform: 'translate3d(-10px, 0, 0) scaleX(0.98)', offset: 0.75},
+          {transform: 'translate3d(5px, 0, 0) scaleX(0.995)', offset: 0.9},
+          {transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      bounceInRight: (t = 1e3, e = 'cubic-bezier(0.215, 0.61, 0.355, 1)', a = 1) => ({
+        keyframes: [
+          {opacity: 0, transform: 'translate3d(3000px, 0, 0) scaleX(3)', offset: 0},
+          {opacity: 1, transform: 'translate3d(-25px, 0, 0) scaleX(1)', offset: 0.6},
+          {transform: 'translate3d(10px, 0, 0) scaleX(0.98)', offset: 0.75},
+          {transform: 'translate3d(-5px, 0, 0) scaleX(0.995)', offset: 0.9},
+          {transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      bounceInUp: (t = 1e3, e = 'cubic-bezier(0.215, 0.61, 0.355, 1)', a = 1) => ({
+        keyframes: [
+          {opacity: 0, transform: 'translate3d(0, 3000px, 0) scaleY(5)', offset: 0},
+          {opacity: 1, transform: 'translate3d(0, -20px, 0) scaleY(0.9)', offset: 0.6},
+          {transform: 'translate3d(0, 10px, 0) scaleY(0.95)', offset: 0.75},
+          {transform: 'translate3d(0, -5px, 0) scaleY(0.985)', offset: 0.9},
+          {transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+    },
+    ...{
+      bounceOutDown: (t = 1e3, e = 'cubic-bezier(0.215, 0.61, 0.355, 1)', a = 1) => ({
+        keyframes: [
+          {transform: 'translate3d(0, 10px, 0) scaleY(0.985)', offset: 0.2},
+          {opacity: 1, transform: 'translate3d(0, -20px, 0) scaleY(0.9)', offset: 0.45},
+          {opacity: 0, transform: 'translate3d(0, 2000px, 0) scaleY(3)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      bounceOutLeft: (t = 1e3, e = 'cubic-bezier(0.215, 0.61, 0.355, 1)', a = 1) => ({
+        keyframes: [
+          {opacity: 1, transform: 'translate3d(20px, 0, 0) scaleX(0.9)', offset: 0.2},
+          {opacity: 0, transform: 'translate3d(-2000px, 0, 0) scaleX(2)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      bounceOutRight: (t = 1e3, e = 'cubic-bezier(0.215, 0.61, 0.355, 1)', a = 1) => ({
+        keyframes: [
+          {opacity: 1, transform: 'translate3d(-20px, 0, 0) scaleX(0.9)', offset: 0.2},
+          {opacity: 0, transform: 'translate3d(2000px, 0, 0) scaleX(2)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      bounceOutUp: (t = 1e3, e = 'cubic-bezier(0.215, 0.61, 0.355, 1)', a = 1) => ({
+        keyframes: [
+          {transform: 'translate3d(0, -10px, 0) scaleY(0.985)', offset: 0.2},
+          {opacity: 1, transform: 'translate3d(0, 20px, 0) scaleY(0.9)', offset: 0.4},
+          {opacity: 1, transform: 'translate3d(0, 20px, 0) scaleY(0.9)', offset: 0.45},
+          {opacity: 0, transform: 'translate3d(0, -2000px, 0) scaleY(3)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+    },
+    ...{
+      fadeIn: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 0, offset: 0},
+          {opacity: 1, offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeInBottomLeft: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 0, transform: 'translate3d(-100%, 100%, 0)', offset: 0},
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeInBottomRight: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 0, transform: 'translate3d(100%, 100%, 0)', offset: 0},
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeInDown: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 0, transform: 'translate3d(0, -100%, 0)', offset: 0},
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeInDownBig: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 0, transform: 'translate3d(0, -2000px, 0)', offset: 0},
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeInLeft: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 0, transform: 'translate3d(-100%, 0, 0)', offset: 0},
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeInLeftBig: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 0, transform: 'translate3d(-2000px, 0, 0)', offset: 0},
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeInRight: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 0, transform: 'translate3d(100%, 0, 0)', offset: 0},
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeInRightBig: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 0, transform: 'translate3d(2000px, 0, 0)', offset: 0},
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeInTopLeft: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 0, transform: 'translate3d(-100%, -100%, 0)', offset: 0},
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeInTopRight: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 0, transform: 'translate3d(100%, -100%, 0)', offset: 0},
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeInUp: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 0, transform: 'translate3d(0, 100%, 0)', offset: 0},
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeInUpBig: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 0, transform: 'translate3d(0, 2000px, 0)', offset: 0},
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+    },
+    ...{
+      fadeOut: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 1, offset: 0},
+          {opacity: 0, offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeOutBottomLeft: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+          {opacity: 0, transform: 'translate3d(-100%, 100%, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeOutBottomRight: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+          {opacity: 0, transform: 'translate3d(100%, 100%, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeOutDown: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+          {opacity: 0, transform: 'translate3d(0, 100%, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeOutDownBig: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+          {opacity: 0, transform: 'translate3d(0, 2000px, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeOutLeft: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+          {opacity: 0, transform: 'translate3d(-100%, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeOutLeftBig: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+          {opacity: 0, transform: 'translate3d(-2000px, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeOutRight: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+          {opacity: 0, transform: 'translate3d(100%, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeOutRightBig: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+          {opacity: 0, transform: 'translate3d(2000px, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeOutTopLeft: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+          {opacity: 0, transform: 'translate3d(-100%, -100%, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeOutTopRight: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+          {opacity: 0, transform: 'translate3d(100%, -100%, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeOutUp: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+          {opacity: 0, transform: 'translate3d(0, -100%, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      fadeOutUpBig: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+          {opacity: 0, transform: 'translate3d(0, -2000px, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+    },
+    ...{
+      flip: (t = 1e3, e = 'ease-out', a = 1) => ({
+        keyframes: [
+          {
+            transform:
+              'perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 0) rotate3d(0, 1, 0, -360deg)',
+            offset: 0,
+            easing: 'ease-out',
+          },
+          {
+            transform:
+              'perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 150px) rotate3d(0, 1, 0, -190deg)',
+            offset: 0.4,
+            easing: 'ease-out',
+          },
+          {
+            transform:
+              'perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 150px) rotate3d(0, 1, 0, -170deg)',
+            offset: 0.5,
+            easing: 'ease-in',
+          },
+          {
+            transform:
+              'perspective(400px) scale3d(0.95, 0.95, 0.95) translate3d(0, 0, 0) rotate3d(0, 1, 0, 0deg)',
+            offset: 0.8,
+            easing: 'ease-in',
+          },
+          {
+            transform:
+              'perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 0) rotate3d(0, 1, 0, 0deg)',
+            offset: 1,
+            easing: 'ease-in',
+          },
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      flipInX: (t = 1e3, e = 'ease-in', a = 1) => ({
+        keyframes: [
+          {
+            transform: 'perspective(400px) rotate3d(1, 0, 0, 90deg)',
+            opacity: 0,
+            offset: 0,
+            easing: 'ease-in',
+          },
+          {
+            transform: 'perspective(400px) rotate3d(1, 0, 0, -20deg)',
+            offset: 0.4,
+            easing: 'ease-in',
+          },
+          {transform: 'perspective(400px) rotate3d(1, 0, 0, 10deg)', opacity: 1, offset: 0.6},
+          {transform: 'perspective(400px) rotate3d(1, 0, 0, -5deg)', offset: 0.8},
+          {transform: 'perspective(400px)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      flipInY: (t = 1e3, e = 'ease-in', a = 1) => ({
+        keyframes: [
+          {
+            transform: 'perspective(400px) rotate3d(0, 1, 0, 90deg)',
+            opacity: 0,
+            offset: 0,
+            easing: 'ease-in',
+          },
+          {
+            transform: 'perspective(400px) rotate3d(0, 1, 0, -20deg)',
+            offset: 0.4,
+            easing: 'ease-in',
+          },
+          {transform: 'perspective(400px) rotate3d(0, 1, 0, 10deg)', opacity: 1, offset: 0.6},
+          {transform: 'perspective(400px) rotate3d(0, 1, 0, -5deg)', offset: 0.8},
+          {transform: 'perspective(400px)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      flipOutX: (t = 1e3, e = 'ease-in', a = 1) => ({
+        keyframes: [
+          {transform: 'perspective(400px)', offset: 0},
+          {transform: 'perspective(400px) rotate3d(1, 0, 0, -20deg)', opacity: 1, offset: 0.3},
+          {transform: 'perspective(400px) rotate3d(1, 0, 0, 90deg)', opacity: 0, offset: 1},
+        ],
+        config: {duration: 0.75 * t, easing: e, iterations: a},
+      }),
+      flipOutY: (t = 1e3, e = 'ease-in', a = 1) => ({
+        keyframes: [
+          {transform: 'perspective(400px)', offset: 0},
+          {transform: 'perspective(400px) rotate3d(0, 1, 0, -15deg)', opacity: 1, offset: 0.3},
+          {transform: 'perspective(400px) rotate3d(0, 1, 0, 90deg)', opacity: 0, offset: 1},
+        ],
+        config: {duration: 0.75 * t, easing: e, iterations: a},
+      }),
+    },
+    ...{
+      lightSpeedInLeft: (t = 1e3, e = 'ease-out', a = 1) => ({
+        keyframes: [
+          {transform: 'translate3d(-100%, 0, 0) skewX(30deg)', opacity: 0, offset: 0},
+          {transform: 'skewX(-20deg)', opacity: 1, offset: 0.6},
+          {transform: 'skewX(5deg)', offset: 0.8},
+          {transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      lightSpeedInRight: (t = 1e3, e = 'ease-out', a = 1) => ({
+        keyframes: [
+          {transform: 'translate3d(100%, 0, 0) skewX(-30deg)', opacity: 0, offset: 0},
+          {transform: 'skewX(20deg)', opacity: 1, offset: 0.6},
+          {transform: 'skewX(-5deg)', offset: 0.8},
+          {transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      lightSpeedOutLeft: (t = 1e3, e = 'ease-in', a = 1) => ({
+        keyframes: [
+          {opacity: 1, offset: 0},
+          {transform: 'translate3d(-100%, 0, 0) skewX(-30deg)', opacity: 0, offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      lightSpeedOutRight: (t = 1e3, e = 'ease-in', a = 1) => ({
+        keyframes: [
+          {opacity: 1, offset: 0},
+          {transform: 'translate3d(100%, 0, 0) skewX(30deg)', opacity: 0, offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+    },
+    ...{
+      rotateIn: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {transform: 'rotate3d(0, 0, 1, -200deg)', opacity: 0, offset: 0},
+          {transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      rotateInDownLeft: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {transform: 'rotate3d(0, 0, 1, -45deg)', opacity: 0, offset: 0},
+          {transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      rotateInDownRight: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {transform: 'rotate3d(0, 0, 1, 45deg)', opacity: 0, offset: 0},
+          {transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      rotateInUpLeft: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {transform: 'rotate3d(0, 0, 1, 45deg)', opacity: 0, offset: 0},
+          {transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      rotateInUpRight: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {transform: 'rotate3d(0, 0, 1, -90deg)', opacity: 0, offset: 0},
+          {transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+    },
+    ...{
+      rotateOut: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {opacity: 1, offset: 0},
+          {transform: 'rotate3d(0, 0, 1, 200deg)', opacity: 0, offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      rotateOutDownLeft: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {opacity: 1, offset: 0},
+          {transform: 'rotate3d(0, 0, 1, 45deg)', opacity: 0, offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      rotateOutDownRight: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {opacity: 1, offset: 0},
+          {transform: 'rotate3d(0, 0, 1, -45deg)', opacity: 0, offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      rotateOutUpLeft: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {opacity: 1, offset: 0},
+          {transform: 'rotate3d(0, 0, 1, -45deg)', opacity: 0, offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      rotateOutUpRight: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {opacity: 1, offset: 0},
+          {transform: 'rotate3d(0, 0, 1, 90deg)', opacity: 0, offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+    },
+    ...{
+      slideInDown: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {transform: 'translate3d(0, -100%, 0)', visibility: 'visible', offset: 0},
+          {transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      slideInLeft: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {transform: 'translate3d(-100%, 0, 0)', visibility: 'visible', offset: 0},
+          {transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      slideInRight: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {transform: 'translate3d(100%, 0, 0)', visibility: 'visible', offset: 0},
+          {transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      slideInUp: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {transform: 'translate3d(0, 100%, 0)', visibility: 'visible', offset: 0},
+          {transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+    },
+    ...{
+      slideOutDown: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {transform: 'translate3d(0, 0, 0)', offset: 0},
+          {visibility: 'hidden', transform: 'translate3d(0, 100%, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      slideOutLeft: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {transform: 'translate3d(0, 0, 0)', offset: 0},
+          {visibility: 'hidden', transform: 'translate3d(-100%, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      slideOutRight: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {transform: 'translate3d(0, 0, 0)', offset: 0},
+          {visibility: 'hidden', transform: 'translate3d(100%, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      slideOutUp: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {transform: 'translate3d(0, 0, 0)', offset: 0},
+          {visibility: 'hidden', transform: 'translate3d(0, -100%, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+    },
+    ...{
+      hinge: (t = 2e3, e = 'ease-in-out', a = 1) => ({
+        keyframes: [
+          {offset: 0, animationTimingFunction: e},
+          {transform: 'rotate3d(0, 0, 1, 80deg)', offset: 0.2, animationTimingFunction: e},
+          {
+            transform: 'rotate3d(0, 0, 1, 60deg)',
+            offset: 0.4,
+            opacity: 1,
+            animationTimingFunction: e,
+          },
+          {
+            transform: 'rotate3d(0, 0, 1, 60deg)',
+            offset: 0.6,
+            opacity: 1,
+            animationTimingFunction: e,
+          },
+          {transform: 'rotate3d(0, 0, 1, 80deg)', offset: 0.8, animationTimingFunction: e},
+          {transform: 'translate3d(0, 700px, 0)', opacity: 0, offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+      }),
+      jackInTheBox: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {
+            opacity: 0,
+            transform: 'scale(0.1) rotate(30deg)',
+            transformOrigin: 'center bottom',
+            offset: 0,
+          },
+          {transform: 'rotate(-10deg)', offset: 0.5},
+          {transform: 'rotate(3deg)', offset: 0.7},
+          {opacity: 1, transform: 'scale(1)', offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      rollIn: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {opacity: 0, transform: 'translate3d(-100%, 0, 0) rotate3d(0, 0, 1, -120deg)', offset: 0},
+          {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      rollOut: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {opacity: 1, transform: 'translate3d(0, 0, 0) rotate3d(0, 0, 1, 0deg)', offset: 0},
+          {opacity: 0, transform: 'translate3d(100%, 0, 0) rotate3d(0, 0, 1, 120deg)', offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+    },
+    ...{
+      zoomIn: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {opacity: 0, transform: 'scale3d(0.3, 0.3, 0.3)', offset: 0},
+          {opacity: 1, transform: 'scale3d(1, 1, 1)', offset: 0.5},
+          {opacity: 1, transform: 'scale3d(1, 1, 1)', offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      zoomInDown: (
+        t = 1e3,
+        e = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+        a = 'cubic-bezier(0.175, 0.885, 0.32, 1)',
+        s = 1,
+      ) => ({
+        keyframes: [
+          {
+            opacity: 0,
+            transform: 'scale3d(0.1, 0.1, 0.1) translate3d(0, -1000px, 0)',
+            offset: 0,
+            easing: e,
+          },
+          {
+            opacity: 1,
+            transform: 'scale3d(0.475, 0.475, 0.475) translate3d(0, 60px, 0)',
+            offset: 0.6,
+            easing: a,
+          },
+          {opacity: 1, transform: 'scale3d(1, 1, 1) translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, iterations: s},
+      }),
+      zoomInLeft: (
+        t = 1e3,
+        e = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+        a = 'cubic-bezier(0.175, 0.885, 0.32, 1)',
+        s = 1,
+      ) => ({
+        keyframes: [
+          {
+            opacity: 0,
+            transform: 'scale3d(0.1, 0.1, 0.1) translate3d(-1000px, 0, 0)',
+            offset: 0,
+            easing: e,
+          },
+          {
+            opacity: 1,
+            transform: 'scale3d(0.475, 0.475, 0.475) translate3d(10px, 0, 0)',
+            offset: 0.6,
+            easing: a,
+          },
+          {opacity: 1, transform: 'scale3d(1, 1, 1) translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, iterations: s},
+      }),
+      zoomInRight: (
+        t = 1e3,
+        e = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+        a = 'cubic-bezier(0.175, 0.885, 0.32, 1)',
+        s = 1,
+      ) => ({
+        keyframes: [
+          {
+            opacity: 0,
+            transform: 'scale3d(0.1, 0.1, 0.1) translate3d(1000px, 0, 0)',
+            offset: 0,
+            easing: e,
+          },
+          {
+            opacity: 1,
+            transform: 'scale3d(0.475, 0.475, 0.475) translate3d(-10px, 0, 0)',
+            offset: 0.6,
+            easing: a,
+          },
+          {opacity: 1, transform: 'scale3d(1, 1, 1) translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, iterations: s},
+      }),
+      zoomInUp: (
+        t = 1e3,
+        e = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+        a = 'cubic-bezier(0.175, 0.885, 0.32, 1)',
+        s = 1,
+      ) => ({
+        keyframes: [
+          {
+            opacity: 0,
+            transform: 'scale3d(0.1, 0.1, 0.1) translate3d(0, 1000px, 0)',
+            offset: 0,
+            easing: e,
+          },
+          {
+            opacity: 1,
+            transform: 'scale3d(0.475, 0.475, 0.475) translate3d(0, -60px, 0)',
+            offset: 0.6,
+            easing: a,
+          },
+          {opacity: 1, transform: 'scale3d(1, 1, 1) translate3d(0, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, iterations: s},
+      }),
+    },
+    ...{
+      zoomOut: (t = 1e3, e = 1, a = 'ease') => ({
+        keyframes: [
+          {opacity: 1, transform: 'scale3d(1, 1, 1)', offset: 0},
+          {opacity: 0, transform: 'scale3d(0.3, 0.3, 0.3)', offset: 0.5},
+          {opacity: 0, transform: 'scale3d(0.3, 0.3, 0.3)', offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+      }),
+      zoomOutDown: (
+        t = 1e3,
+        e = 1,
+        a = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+        s = 'cubic-bezier(0.175, 0.885, 0.32, 1)',
+      ) => ({
+        keyframes: [
+          {
+            opacity: 1,
+            transform: 'scale3d(0.475, 0.475, 0.475) translate3d(0, -60px, 0)',
+            offset: 0.4,
+            easing: a,
+          },
+          {
+            opacity: 0,
+            transform: 'scale3d(0.1, 0.1, 0.1) translate3d(0, 2000px, 0)',
+            offset: 1,
+            easing: s,
+          },
+        ],
+        config: {duration: t, iterations: e},
+      }),
+      zoomOutLeft: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {
+            opacity: 1,
+            transform: 'scale3d(0.475, 0.475, 0.475) translate3d(42px, 0, 0)',
+            offset: 0.4,
+          },
+          {opacity: 0, transform: 'scale(0.1) translate3d(-2000px, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+        transformOrigin: 'left center',
+      }),
+      zoomOutRight: (t = 1e3, e = 'linear', a = 1) => ({
+        keyframes: [
+          {
+            opacity: 1,
+            transform: 'scale3d(0.475, 0.475, 0.475) translate3d(-42px, 0, 0)',
+            offset: 0.4,
+          },
+          {opacity: 0, transform: 'scale(0.1) translate3d(2000px, 0, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: e, iterations: a},
+        transformOrigin: 'right center',
+      }),
+      zoomOutUp: (t = 1e3, e = 1, a = 'linear') => ({
+        keyframes: [
+          {
+            opacity: 1,
+            transform: 'scale3d(0.475, 0.475, 0.475) translate3d(0, 60px, 0)',
+            offset: 0.4,
+          },
+          {opacity: 0, transform: 'scale3d(0.1, 0.1, 0.1) translate3d(0, -2000px, 0)', offset: 1},
+        ],
+        config: {duration: t, easing: a, iterations: e},
+        transformOrigin: 'center bottom',
+        timingFunction: [
+          'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+          'cubic-bezier(0.175, 0.885, 0.32, 1)',
+        ],
+      }),
+    },
+  });
+});

--- a/animate-css.mjs
+++ b/animate-css.mjs
@@ -1,0 +1,1749 @@
+function getDefaultExportFromCjs(x) {
+  return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+}
+
+const bounce = (duration, iterations = 1, easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)') => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 0, 0)', offset: 0},
+      {transform: 'translate3d(0, -30px, 0) scaleY(1.1)', offset: 0.4},
+      {transform: 'translate3d(0, -15px, 0) scaleY(1.05)', offset: 0.7},
+      {transform: 'translate3d(0, 0, 0) scaleY(0.95)', offset: 0.8},
+      {transform: 'translate3d(0, -4px, 0) scaleY(1.02)', offset: 0.9},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const flash = (duration = 1000, iterations = Infinity, easing = 'linear') => {
+  return {
+    keyframes: [
+      {opacity: 1, offset: 0},
+      {opacity: 0, offset: 0.25},
+      {opacity: 1, offset: 0.5},
+      {opacity: 0, offset: 0.75},
+      {opacity: 1, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const headShake = (duration = 1000, iterations = 1, easing = 'ease-in-out') => {
+  return {
+    keyframes: [
+      {transform: 'translateX(0) rotateY(0deg)', offset: 0},
+      {transform: 'translateX(-6px) rotateY(-9deg)', offset: 0.065},
+      {transform: 'translateX(5px) rotateY(7deg)', offset: 0.185},
+      {transform: 'translateX(-3px) rotateY(-5deg)', offset: 0.315},
+      {transform: 'translateX(2px) rotateY(3deg)', offset: 0.435},
+      {transform: 'translateX(0) rotateY(0deg)', offset: 0.5},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const heartBeat = (duration = 1000, iterations = Infinity, easing = 'ease-in-out') => {
+  return {
+    keyframes: [
+      {transform: 'scale(1)', offset: 0},
+      {transform: 'scale(1.3)', offset: 0.14},
+      {transform: 'scale(1)', offset: 0.28},
+      {transform: 'scale(1.3)', offset: 0.42},
+      {transform: 'scale(1)', offset: 0.7},
+    ],
+    config: {
+      duration: duration * 1.3, // To Fix
+      easing,
+      iterations,
+    },
+  };
+};
+const jello = (duration = 1000, iterations = Infinity, easing = 'ease-in-out') => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 0, 0)', offset: 0},
+      {transform: 'skewX(-12.5deg) skewY(-12.5deg)', offset: 0.222},
+      {transform: 'skewX(6.25deg) skewY(6.25deg)', offset: 0.333},
+      {transform: 'skewX(-3.125deg) skewY(-3.125deg)', offset: 0.444},
+      {transform: 'skewX(1.5625deg) skewY(1.5625deg)', offset: 0.555},
+      {transform: 'skewX(-0.78125deg) skewY(-0.78125deg)', offset: 0.666},
+      {transform: 'skewX(0.390625deg) skewY(0.390625deg)', offset: 0.777},
+      {transform: 'skewX(-0.1953125deg) skewY(-0.1953125deg)', offset: 0.888},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const pulse = (duration = 1000, iterations = Infinity, easing = 'ease-in-out') => {
+  return {
+    keyframes: [
+      {transform: 'scale3d(1, 1, 1)', offset: 0},
+      {transform: 'scale3d(1.05, 1.05, 1.05)', offset: 0.5},
+      {transform: 'scale3d(1, 1, 1)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const rubberBand = (duration = 1000, iterations = 1, easing = 'ease-in-out') => {
+  return {
+    keyframes: [
+      {transform: 'scale3d(1, 1, 1)', offset: 0},
+      {transform: 'scale3d(1.25, 0.75, 1)', offset: 0.3},
+      {transform: 'scale3d(0.75, 1.25, 1)', offset: 0.4},
+      {transform: 'scale3d(1.15, 0.85, 1)', offset: 0.5},
+      {transform: 'scale3d(0.95, 1.05, 1)', offset: 0.65},
+      {transform: 'scale3d(1.05, 0.95, 1)', offset: 0.75},
+      {transform: 'scale3d(1, 1, 1)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const shake = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 0, 0)', offset: 0},
+      {transform: 'translate3d(-10px, 0, 0)', offset: 0.1},
+      {transform: 'translate3d(10px, 0, 0)', offset: 0.2},
+      {transform: 'translate3d(-10px, 0, 0)', offset: 0.3},
+      {transform: 'translate3d(10px, 0, 0)', offset: 0.4},
+      {transform: 'translate3d(-10px, 0, 0)', offset: 0.5},
+      {transform: 'translate3d(10px, 0, 0)', offset: 0.6},
+      {transform: 'translate3d(-10px, 0, 0)', offset: 0.7},
+      {transform: 'translate3d(10px, 0, 0)', offset: 0.8},
+      {transform: 'translate3d(-10px, 0, 0)', offset: 0.9},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const shakeX = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 0, 0)', offset: 0},
+      {transform: 'translate3d(-10px, 0, 0)', offset: 0.1},
+      {transform: 'translate3d(10px, 0, 0)', offset: 0.2},
+      {transform: 'translate3d(-10px, 0, 0)', offset: 0.3},
+      {transform: 'translate3d(10px, 0, 0)', offset: 0.4},
+      {transform: 'translate3d(-10px, 0, 0)', offset: 0.5},
+      {transform: 'translate3d(10px, 0, 0)', offset: 0.6},
+      {transform: 'translate3d(-10px, 0, 0)', offset: 0.7},
+      {transform: 'translate3d(10px, 0, 0)', offset: 0.8},
+      {transform: 'translate3d(-10px, 0, 0)', offset: 0.9},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const shakeY = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 0, 0)', offset: 0},
+      {transform: 'translate3d(0, -10px, 0)', offset: 0.1},
+      {transform: 'translate3d(0, 10px, 0)', offset: 0.2},
+      {transform: 'translate3d(0, -10px, 0)', offset: 0.3},
+      {transform: 'translate3d(0, 10px, 0)', offset: 0.4},
+      {transform: 'translate3d(0, -10px, 0)', offset: 0.5},
+      {transform: 'translate3d(0, 10px, 0)', offset: 0.6},
+      {transform: 'translate3d(0, -10px, 0)', offset: 0.7},
+      {transform: 'translate3d(0, 10px, 0)', offset: 0.8},
+      {transform: 'translate3d(0, -10px, 0)', offset: 0.9},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const swing = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'rotate3d(0, 0, 1, 0deg)', offset: 0}, // Equivalent to `from`
+      {transform: 'rotate3d(0, 0, 1, 15deg)', offset: 0.2},
+      {transform: 'rotate3d(0, 0, 1, -10deg)', offset: 0.4},
+      {transform: 'rotate3d(0, 0, 1, 5deg)', offset: 0.6},
+      {transform: 'rotate3d(0, 0, 1, -5deg)', offset: 0.8},
+      {transform: 'rotate3d(0, 0, 1, 0deg)', offset: 1}, // Equivalent to `to`
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const tada = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'scale3d(1, 1, 1)', offset: 0},
+      {transform: 'scale3d(0.9, 0.9, 0.9) rotate3d(0, 0, 1, -3deg)', offset: 0.1},
+      {transform: 'scale3d(0.9, 0.9, 0.9) rotate3d(0, 0, 1, -3deg)', offset: 0.2},
+      {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)', offset: 0.3},
+      {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg)', offset: 0.4},
+      {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)', offset: 0.5},
+      {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg)', offset: 0.6},
+      {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)', offset: 0.7},
+      {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg)', offset: 0.8},
+      {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)', offset: 0.9},
+      {transform: 'scale3d(1, 1, 1)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const wobble = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 0, 0)', offset: 0}, // Equivalent to `from`
+      {transform: 'translate3d(-25%, 0, 0) rotate3d(0, 0, 1, -5deg)', offset: 0.15},
+      {transform: 'translate3d(20%, 0, 0) rotate3d(0, 0, 1, 3deg)', offset: 0.3},
+      {transform: 'translate3d(-15%, 0, 0) rotate3d(0, 0, 1, -3deg)', offset: 0.45},
+      {transform: 'translate3d(10%, 0, 0) rotate3d(0, 0, 1, 2deg)', offset: 0.6},
+      {transform: 'translate3d(-5%, 0, 0) rotate3d(0, 0, 1, -1deg)', offset: 0.75},
+      {transform: 'translate3d(0, 0, 0)', offset: 1}, // Equivalent to `to`
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+var attentionSeekers = {
+  bounce,
+  flash,
+  headShake,
+  heartBeat,
+  jello,
+  pulse,
+  rubberBand,
+  shake,
+  shakeX,
+  shakeY,
+  swing,
+  tada,
+  wobble,
+};
+
+const backInDown = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'translateY(-1200px) scale(0.7)', opacity: 0.7, offset: 0},
+      {transform: 'translateY(0px) scale(0.7)', opacity: 0.7, offset: 0.8},
+      {transform: 'scale(1)', opacity: 1, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const backInLeft = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'translateX(-2000px) scale(0.7)', opacity: 0.7, offset: 0},
+      {transform: 'translateX(0px) scale(0.7)', opacity: 0.7, offset: 0.8},
+      {transform: 'scale(1)', opacity: 1, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const backInRight = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'translateX(2000px) scale(0.7)', opacity: 0.7, offset: 0},
+      {transform: 'translateX(0px) scale(0.7)', opacity: 0.7, offset: 0.8},
+      {transform: 'scale(1)', opacity: 1, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const backInUp = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'translateY(1200px) scale(0.7)', opacity: 0.7, offset: 0},
+      {transform: 'translateY(0px) scale(0.7)', opacity: 0.7, offset: 0.8},
+      {transform: 'scale(1)', opacity: 1, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+var backIn = {
+  backInDown,
+  backInLeft,
+  backInRight,
+  backInUp,
+};
+
+const backOutDown = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'scale(1)', opacity: 1, offset: 0},
+      {transform: 'translateY(0px) scale(0.7)', opacity: 0.7, offset: 0.2},
+      {transform: 'translateY(700px) scale(0.7)', opacity: 0.7, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const backOutLeft = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'scale(1)', opacity: 1, offset: 0},
+      {transform: 'translateX(0px) scale(0.7)', opacity: 0.7, offset: 0.2},
+      {transform: 'translateX(-2000px) scale(0.7)', opacity: 0.7, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const backOutRight = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'scale(1)', opacity: 1, offset: 0},
+      {transform: 'translateX(0px) scale(0.7)', opacity: 0.7, offset: 0.2},
+      {transform: 'translateX(2000px) scale(0.7)', opacity: 0.7, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const backOutUp = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'scale(1)', opacity: 1, offset: 0},
+      {transform: 'translateY(0px) scale(0.7)', opacity: 0.7, offset: 0.2},
+      {transform: 'translateY(-700px) scale(0.7)', opacity: 0.7, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+var backOut = {
+  backOutDown,
+  backOutLeft,
+  backOutRight,
+  backOutUp,
+};
+
+const bounceIn = (
+  duration = 1000,
+  easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'scale3d(0.3, 0.3, 0.3)', offset: 0},
+      {transform: 'scale3d(1.1, 1.1, 1.1)', offset: 0.2},
+      {transform: 'scale3d(0.9, 0.9, 0.9)', offset: 0.4},
+      {opacity: 1, transform: 'scale3d(1.03, 1.03, 1.03)', offset: 0.6},
+      {transform: 'scale3d(0.97, 0.97, 0.97)', offset: 0.8},
+      {opacity: 1, transform: 'scale3d(1, 1, 1)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const bounceInDown = (
+  duration = 1000,
+  easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(0, -3000px, 0) scaleY(3)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 25px, 0) scaleY(0.9)', offset: 0.6},
+      {transform: 'translate3d(0, -10px, 0) scaleY(0.95)', offset: 0.75},
+      {transform: 'translate3d(0, 5px, 0) scaleY(0.985)', offset: 0.9},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const bounceInLeft = (
+  duration = 1000,
+  easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(-3000px, 0, 0) scaleX(3)', offset: 0},
+      {opacity: 1, transform: 'translate3d(25px, 0, 0) scaleX(1)', offset: 0.6},
+      {transform: 'translate3d(-10px, 0, 0) scaleX(0.98)', offset: 0.75},
+      {transform: 'translate3d(5px, 0, 0) scaleX(0.995)', offset: 0.9},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const bounceInRight = (
+  duration = 1000,
+  easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(3000px, 0, 0) scaleX(3)', offset: 0},
+      {opacity: 1, transform: 'translate3d(-25px, 0, 0) scaleX(1)', offset: 0.6},
+      {transform: 'translate3d(10px, 0, 0) scaleX(0.98)', offset: 0.75},
+      {transform: 'translate3d(-5px, 0, 0) scaleX(0.995)', offset: 0.9},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const bounceInUp = (
+  duration = 1000,
+  easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(0, 3000px, 0) scaleY(5)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, -20px, 0) scaleY(0.9)', offset: 0.6},
+      {transform: 'translate3d(0, 10px, 0) scaleY(0.95)', offset: 0.75},
+      {transform: 'translate3d(0, -5px, 0) scaleY(0.985)', offset: 0.9},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+var bounceIn_1 = {
+  bounceIn,
+  bounceInDown,
+  bounceInLeft,
+  bounceInRight,
+  bounceInUp,
+};
+
+const bounceOutDown = (
+  duration = 1000,
+  easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 10px, 0) scaleY(0.985)', offset: 0.2},
+      {opacity: 1, transform: 'translate3d(0, -20px, 0) scaleY(0.9)', offset: 0.45},
+      {opacity: 0, transform: 'translate3d(0, 2000px, 0) scaleY(3)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const bounceOutLeft = (
+  duration = 1000,
+  easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(20px, 0, 0) scaleX(0.9)', offset: 0.2},
+      {opacity: 0, transform: 'translate3d(-2000px, 0, 0) scaleX(2)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const bounceOutRight = (
+  duration = 1000,
+  easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(-20px, 0, 0) scaleX(0.9)', offset: 0.2},
+      {opacity: 0, transform: 'translate3d(2000px, 0, 0) scaleX(2)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const bounceOutUp = (
+  duration = 1000,
+  easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, -10px, 0) scaleY(0.985)', offset: 0.2},
+      {opacity: 1, transform: 'translate3d(0, 20px, 0) scaleY(0.9)', offset: 0.4},
+      {opacity: 1, transform: 'translate3d(0, 20px, 0) scaleY(0.9)', offset: 0.45},
+      {opacity: 0, transform: 'translate3d(0, -2000px, 0) scaleY(3)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+var bounceOut_1 = {
+  bounceOutDown,
+  bounceOutLeft,
+  bounceOutRight,
+  bounceOutUp,
+};
+
+const fadeIn = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, offset: 0},
+      {opacity: 1, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInBottomLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(-100%, 100%, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInBottomRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(100%, 100%, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInDown = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(0, -100%, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInDownBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(0, -2000px, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(-100%, 0, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInLeftBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(-2000px, 0, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(100%, 0, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInRightBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(2000px, 0, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInTopLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(-100%, -100%, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInTopRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(100%, -100%, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInUp = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(0, 100%, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInUpBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(0, 2000px, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+var fadeIn_1 = {
+  fadeIn,
+  fadeInBottomLeft,
+  fadeInBottomRight,
+  fadeInDown,
+  fadeInDownBig,
+  fadeInLeft,
+  fadeInLeftBig,
+  fadeInRight,
+  fadeInRightBig,
+  fadeInTopLeft,
+  fadeInTopRight,
+  fadeInUp,
+  fadeInUpBig,
+};
+
+const fadeOut = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, offset: 0},
+      {opacity: 0, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutBottomLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(-100%, 100%, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutBottomRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(100%, 100%, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutDown = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(0, 100%, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutDownBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(0, 2000px, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(-100%, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutLeftBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(-2000px, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(100%, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutRightBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(2000px, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutTopLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(-100%, -100%, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutTopRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(100%, -100%, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutUp = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(0, -100%, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutUpBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(0, -2000px, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+var fadeOut_1 = {
+  fadeOut,
+  fadeOutBottomLeft,
+  fadeOutBottomRight,
+  fadeOutDown,
+  fadeOutDownBig,
+  fadeOutLeft,
+  fadeOutLeftBig,
+  fadeOutRight,
+  fadeOutRightBig,
+  fadeOutTopLeft,
+  fadeOutTopRight,
+  fadeOutUp,
+  fadeOutUpBig,
+};
+
+const flip = (duration = 1000, easing = 'ease-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {
+        transform:
+          'perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 0) rotate3d(0, 1, 0, -360deg)',
+        offset: 0,
+        easing: 'ease-out',
+      },
+      {
+        transform:
+          'perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 150px) rotate3d(0, 1, 0, -190deg)',
+        offset: 0.4,
+        easing: 'ease-out',
+      },
+      {
+        transform:
+          'perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 150px) rotate3d(0, 1, 0, -170deg)',
+        offset: 0.5,
+        easing: 'ease-in',
+      },
+      {
+        transform:
+          'perspective(400px) scale3d(0.95, 0.95, 0.95) translate3d(0, 0, 0) rotate3d(0, 1, 0, 0deg)',
+        offset: 0.8,
+        easing: 'ease-in',
+      },
+      {
+        transform:
+          'perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 0) rotate3d(0, 1, 0, 0deg)',
+        offset: 1,
+        easing: 'ease-in',
+      },
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const flipInX = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+  return {
+    keyframes: [
+      {
+        transform: 'perspective(400px) rotate3d(1, 0, 0, 90deg)',
+        opacity: 0,
+        offset: 0,
+        easing: 'ease-in',
+      },
+      {transform: 'perspective(400px) rotate3d(1, 0, 0, -20deg)', offset: 0.4, easing: 'ease-in'},
+      {transform: 'perspective(400px) rotate3d(1, 0, 0, 10deg)', opacity: 1, offset: 0.6},
+      {transform: 'perspective(400px) rotate3d(1, 0, 0, -5deg)', offset: 0.8},
+      {transform: 'perspective(400px)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const flipInY = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+  return {
+    keyframes: [
+      {
+        transform: 'perspective(400px) rotate3d(0, 1, 0, 90deg)',
+        opacity: 0,
+        offset: 0,
+        easing: 'ease-in',
+      },
+      {transform: 'perspective(400px) rotate3d(0, 1, 0, -20deg)', offset: 0.4, easing: 'ease-in'},
+      {transform: 'perspective(400px) rotate3d(0, 1, 0, 10deg)', opacity: 1, offset: 0.6},
+      {transform: 'perspective(400px) rotate3d(0, 1, 0, -5deg)', offset: 0.8},
+      {transform: 'perspective(400px)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const flipOutX = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'perspective(400px)', offset: 0},
+      {transform: 'perspective(400px) rotate3d(1, 0, 0, -20deg)', opacity: 1, offset: 0.3},
+      {transform: 'perspective(400px) rotate3d(1, 0, 0, 90deg)', opacity: 0, offset: 1},
+    ],
+    config: {
+      duration: duration * 0.75,
+      easing,
+      iterations,
+    },
+  };
+};
+const flipOutY = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'perspective(400px)', offset: 0},
+      {transform: 'perspective(400px) rotate3d(0, 1, 0, -15deg)', opacity: 1, offset: 0.3},
+      {transform: 'perspective(400px) rotate3d(0, 1, 0, 90deg)', opacity: 0, offset: 1},
+    ],
+    config: {
+      duration: duration * 0.75,
+      easing,
+      iterations,
+    },
+  };
+};
+var flippers = {
+  flip,
+  flipInX,
+  flipInY,
+  flipOutX,
+  flipOutY,
+};
+
+const lightSpeedInLeft = (duration = 1000, easing = 'ease-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(-100%, 0, 0) skewX(30deg)', opacity: 0, offset: 0},
+      {transform: 'skewX(-20deg)', opacity: 1, offset: 0.6},
+      {transform: 'skewX(5deg)', offset: 0.8},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const lightSpeedInRight = (duration = 1000, easing = 'ease-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(100%, 0, 0) skewX(-30deg)', opacity: 0, offset: 0},
+      {transform: 'skewX(20deg)', opacity: 1, offset: 0.6},
+      {transform: 'skewX(-5deg)', offset: 0.8},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const lightSpeedOutLeft = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, offset: 0},
+      {transform: 'translate3d(-100%, 0, 0) skewX(-30deg)', opacity: 0, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const lightSpeedOutRight = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, offset: 0},
+      {transform: 'translate3d(100%, 0, 0) skewX(30deg)', opacity: 0, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+var lightspeed = {
+  lightSpeedInLeft,
+  lightSpeedInRight,
+  lightSpeedOutLeft,
+  lightSpeedOutRight,
+};
+
+const rotateIn = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'rotate3d(0, 0, 1, -200deg)', opacity: 0, offset: 0},
+      {transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const rotateInDownLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'rotate3d(0, 0, 1, -45deg)', opacity: 0, offset: 0},
+      {transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const rotateInDownRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'rotate3d(0, 0, 1, 45deg)', opacity: 0, offset: 0},
+      {transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const rotateInUpLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'rotate3d(0, 0, 1, 45deg)', opacity: 0, offset: 0},
+      {transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const rotateInUpRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'rotate3d(0, 0, 1, -90deg)', opacity: 0, offset: 0},
+      {transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+var rotateIn_1 = {
+  rotateIn,
+  rotateInDownLeft,
+  rotateInDownRight,
+  rotateInUpLeft,
+  rotateInUpRight,
+};
+
+const rotateOut = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {opacity: 1, offset: 0},
+      {transform: 'rotate3d(0, 0, 1, 200deg)', opacity: 0, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const rotateOutDownLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {opacity: 1, offset: 0},
+      {transform: 'rotate3d(0, 0, 1, 45deg)', opacity: 0, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const rotateOutDownRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {opacity: 1, offset: 0},
+      {transform: 'rotate3d(0, 0, 1, -45deg)', opacity: 0, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const rotateOutUpLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {opacity: 1, offset: 0},
+      {transform: 'rotate3d(0, 0, 1, -45deg)', opacity: 0, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const rotateOutUpRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {opacity: 1, offset: 0},
+      {transform: 'rotate3d(0, 0, 1, 90deg)', opacity: 0, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+var rotateOut_1 = {
+  rotateOut,
+  rotateOutDownLeft,
+  rotateOutDownRight,
+  rotateOutUpLeft,
+  rotateOutUpRight,
+};
+
+const slideInDown = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, -100%, 0)', visibility: 'visible', offset: 0},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const slideInLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(-100%, 0, 0)', visibility: 'visible', offset: 0},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const slideInRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(100%, 0, 0)', visibility: 'visible', offset: 0},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const slideInUp = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 100%, 0)', visibility: 'visible', offset: 0},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+var slideIn = {
+  slideInDown,
+  slideInLeft,
+  slideInRight,
+  slideInUp,
+};
+
+const slideOutDown = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 0, 0)', offset: 0},
+      {visibility: 'hidden', transform: 'translate3d(0, 100%, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const slideOutLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 0, 0)', offset: 0},
+      {visibility: 'hidden', transform: 'translate3d(-100%, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const slideOutRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 0, 0)', offset: 0},
+      {visibility: 'hidden', transform: 'translate3d(100%, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const slideOutUp = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 0, 0)', offset: 0},
+      {visibility: 'hidden', transform: 'translate3d(0, -100%, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+var slideOut = {
+  slideOutDown,
+  slideOutLeft,
+  slideOutRight,
+  slideOutUp,
+};
+
+const hinge = (duration = 2000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {offset: 0, animationTimingFunction: easing},
+      {transform: 'rotate3d(0, 0, 1, 80deg)', offset: 0.2, animationTimingFunction: easing},
+      {
+        transform: 'rotate3d(0, 0, 1, 60deg)',
+        offset: 0.4,
+        opacity: 1,
+        animationTimingFunction: easing,
+      },
+      {
+        transform: 'rotate3d(0, 0, 1, 60deg)',
+        offset: 0.6,
+        opacity: 1,
+        animationTimingFunction: easing,
+      },
+      {transform: 'rotate3d(0, 0, 1, 80deg)', offset: 0.8, animationTimingFunction: easing},
+      {transform: 'translate3d(0, 700px, 0)', opacity: 0, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const jackInTheBox = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {
+        opacity: 0,
+        transform: 'scale(0.1) rotate(30deg)',
+        transformOrigin: 'center bottom',
+        offset: 0,
+      },
+      {transform: 'rotate(-10deg)', offset: 0.5},
+      {transform: 'rotate(3deg)', offset: 0.7},
+      {opacity: 1, transform: 'scale(1)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const rollIn = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(-100%, 0, 0) rotate3d(0, 0, 1, -120deg)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const rollOut = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0) rotate3d(0, 0, 1, 0deg)', offset: 0},
+      {opacity: 0, transform: 'translate3d(100%, 0, 0) rotate3d(0, 0, 1, 120deg)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+var specials = {
+  hinge,
+  jackInTheBox,
+  rollIn,
+  rollOut,
+};
+
+const zoomIn = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'scale3d(0.3, 0.3, 0.3)', offset: 0},
+      {opacity: 1, transform: 'scale3d(1, 1, 1)', offset: 0.5},
+      {opacity: 1, transform: 'scale3d(1, 1, 1)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const zoomInDown = (
+  duration = 1000,
+  easingIn = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+  easingOut = 'cubic-bezier(0.175, 0.885, 0.32, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {
+        opacity: 0,
+        transform: 'scale3d(0.1, 0.1, 0.1) translate3d(0, -1000px, 0)',
+        offset: 0,
+        easing: easingIn,
+      },
+      {
+        opacity: 1,
+        transform: 'scale3d(0.475, 0.475, 0.475) translate3d(0, 60px, 0)',
+        offset: 0.6,
+        easing: easingOut,
+      },
+      {
+        opacity: 1,
+        transform: 'scale3d(1, 1, 1) translate3d(0, 0, 0)',
+        offset: 1,
+      },
+    ],
+    config: {
+      duration,
+      iterations,
+    },
+  };
+};
+const zoomInLeft = (
+  duration = 1000,
+  easingIn = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+  easingOut = 'cubic-bezier(0.175, 0.885, 0.32, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {
+        opacity: 0,
+        transform: 'scale3d(0.1, 0.1, 0.1) translate3d(-1000px, 0, 0)',
+        offset: 0,
+        easing: easingIn,
+      },
+      {
+        opacity: 1,
+        transform: 'scale3d(0.475, 0.475, 0.475) translate3d(10px, 0, 0)',
+        offset: 0.6,
+        easing: easingOut,
+      },
+      {
+        opacity: 1,
+        transform: 'scale3d(1, 1, 1) translate3d(0, 0, 0)',
+        offset: 1,
+      },
+    ],
+    config: {
+      duration,
+      iterations,
+    },
+  };
+};
+const zoomInRight = (
+  duration = 1000,
+  easingIn = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+  easingOut = 'cubic-bezier(0.175, 0.885, 0.32, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {
+        opacity: 0,
+        transform: 'scale3d(0.1, 0.1, 0.1) translate3d(1000px, 0, 0)',
+        offset: 0,
+        easing: easingIn,
+      },
+      {
+        opacity: 1,
+        transform: 'scale3d(0.475, 0.475, 0.475) translate3d(-10px, 0, 0)',
+        offset: 0.6,
+        easing: easingOut,
+      },
+      {
+        opacity: 1,
+        transform: 'scale3d(1, 1, 1) translate3d(0, 0, 0)',
+        offset: 1,
+      },
+    ],
+    config: {
+      duration,
+      iterations,
+    },
+  };
+};
+const zoomInUp = (
+  duration = 1000,
+  easingIn = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+  easingOut = 'cubic-bezier(0.175, 0.885, 0.32, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {
+        opacity: 0,
+        transform: 'scale3d(0.1, 0.1, 0.1) translate3d(0, 1000px, 0)',
+        offset: 0,
+        easing: easingIn,
+      },
+      {
+        opacity: 1,
+        transform: 'scale3d(0.475, 0.475, 0.475) translate3d(0, -60px, 0)',
+        offset: 0.6,
+        easing: easingOut,
+      },
+      {
+        opacity: 1,
+        transform: 'scale3d(1, 1, 1) translate3d(0, 0, 0)',
+        offset: 1,
+      },
+    ],
+    config: {
+      duration,
+      iterations,
+    },
+  };
+};
+var zoomIn_1 = {
+  zoomIn,
+  zoomInDown,
+  zoomInLeft,
+  zoomInRight,
+  zoomInUp,
+};
+
+const zoomOut = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {
+        opacity: 1,
+        transform: 'scale3d(1, 1, 1)',
+        offset: 0,
+      },
+      {
+        opacity: 0,
+        transform: 'scale3d(0.3, 0.3, 0.3)',
+        offset: 0.5,
+      },
+      {
+        opacity: 0,
+        transform: 'scale3d(0.3, 0.3, 0.3)',
+        offset: 1,
+      },
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const zoomOutDown = (
+  duration = 1000,
+  iterations = 1,
+  easingIn = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+  easingOut = 'cubic-bezier(0.175, 0.885, 0.32, 1)',
+) => {
+  return {
+    keyframes: [
+      {
+        opacity: 1,
+        transform: 'scale3d(0.475, 0.475, 0.475) translate3d(0, -60px, 0)',
+        offset: 0.4,
+        easing: easingIn,
+      },
+      {
+        opacity: 0,
+        transform: 'scale3d(0.1, 0.1, 0.1) translate3d(0, 2000px, 0)',
+        offset: 1,
+        easing: easingOut,
+      },
+    ],
+    config: {
+      duration,
+      iterations,
+    },
+  };
+};
+const zoomOutLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'scale3d(0.475, 0.475, 0.475) translate3d(42px, 0, 0)', offset: 0.4},
+      {opacity: 0, transform: 'scale(0.1) translate3d(-2000px, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+    transformOrigin: 'left center',
+  };
+};
+const zoomOutRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'scale3d(0.475, 0.475, 0.475) translate3d(-42px, 0, 0)', offset: 0.4},
+      {opacity: 0, transform: 'scale(0.1) translate3d(2000px, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+    transformOrigin: 'right center',
+  };
+};
+const zoomOutUp = (duration = 1000, iterations = 1, easing = 'linear') => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'scale3d(0.475, 0.475, 0.475) translate3d(0, 60px, 0)', offset: 0.4},
+      {opacity: 0, transform: 'scale3d(0.1, 0.1, 0.1) translate3d(0, -2000px, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+    transformOrigin: 'center bottom',
+    timingFunction: [
+      'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+      'cubic-bezier(0.175, 0.885, 0.32, 1)',
+    ],
+  };
+};
+var zoomOut_1 = {
+  zoomOut,
+  zoomOutDown,
+  zoomOutLeft,
+  zoomOutRight,
+  zoomOutUp,
+};
+
+var js = {
+  ...attentionSeekers,
+  ...backIn,
+  ...backOut,
+  ...bounceIn_1,
+  ...bounceOut_1,
+  ...fadeIn_1,
+  ...fadeOut_1,
+  ...flippers,
+  ...lightspeed,
+  ...rotateIn_1,
+  ...rotateOut_1,
+  ...slideIn,
+  ...slideOut,
+  ...specials,
+  ...zoomIn_1,
+  ...zoomOut_1,
+};
+
+var index = /*@__PURE__*/ getDefaultExportFromCjs(js);
+
+export {index as default};

--- a/animate.css
+++ b/animate.css
@@ -5,7 +5,7 @@
  * Version - 4.1.1
  * Licensed under the Hippocratic License 2.1 - http://firstdonoharm.dev
  *
- * Copyright (c) 2022 Animate.css
+ * Copyright (c) 2024 Animate.css
  */
 :root {
   --animate-duration: 1s;

--- a/js/index.js
+++ b/js/index.js
@@ -1,0 +1,18 @@
+module.exports = {
+  ...require('./keyframes/attention-seekers.js'),
+  ...require('./keyframes/back-in.js'),
+  ...require('./keyframes/back-out.js'),
+  ...require('./keyframes/bounce-in.js'),
+  ...require('./keyframes/bounce-out.js'),
+  ...require('./keyframes/fade-in.js'),
+  ...require('./keyframes/fade-out.js'),
+  ...require('./keyframes/flippers.js'),
+  ...require('./keyframes/lightspeed.js'),
+  ...require('./keyframes/rotate-in.js'),
+  ...require('./keyframes/rotate-out.js'),
+  ...require('./keyframes/slide-in.js'),
+  ...require('./keyframes/slide-out.js'),
+  ...require('./keyframes/specials.js'),
+  ...require('./keyframes/zoom-in.js'),
+  ...require('./keyframes/zoom-out.js'),
+};

--- a/js/keyframes/attention-seekers.js
+++ b/js/keyframes/attention-seekers.js
@@ -1,0 +1,256 @@
+const bounce = (duration, iterations = 1, easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)') => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 0, 0)', offset: 0},
+      {transform: 'translate3d(0, -30px, 0) scaleY(1.1)', offset: 0.4},
+      {transform: 'translate3d(0, -15px, 0) scaleY(1.05)', offset: 0.7},
+      {transform: 'translate3d(0, 0, 0) scaleY(0.95)', offset: 0.8},
+      {transform: 'translate3d(0, -4px, 0) scaleY(1.02)', offset: 0.9},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const flash = (duration = 1000, iterations = Infinity, easing = 'linear') => {
+  return {
+    keyframes: [
+      {opacity: 1, offset: 0},
+      {opacity: 0, offset: 0.25},
+      {opacity: 1, offset: 0.5},
+      {opacity: 0, offset: 0.75},
+      {opacity: 1, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const headShake = (duration = 1000, iterations = 1, easing = 'ease-in-out') => {
+  return {
+    keyframes: [
+      {transform: 'translateX(0) rotateY(0deg)', offset: 0},
+      {transform: 'translateX(-6px) rotateY(-9deg)', offset: 0.065},
+      {transform: 'translateX(5px) rotateY(7deg)', offset: 0.185},
+      {transform: 'translateX(-3px) rotateY(-5deg)', offset: 0.315},
+      {transform: 'translateX(2px) rotateY(3deg)', offset: 0.435},
+      {transform: 'translateX(0) rotateY(0deg)', offset: 0.5},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const heartBeat = (duration = 1000, iterations = Infinity, easing = 'ease-in-out') => {
+  return {
+    keyframes: [
+      {transform: 'scale(1)', offset: 0},
+      {transform: 'scale(1.3)', offset: 0.14},
+      {transform: 'scale(1)', offset: 0.28},
+      {transform: 'scale(1.3)', offset: 0.42},
+      {transform: 'scale(1)', offset: 0.7},
+    ],
+    config: {
+      duration: duration * 1.3, // To Fix
+      easing,
+      iterations,
+    },
+  };
+};
+const jello = (duration = 1000, iterations = Infinity, easing = 'ease-in-out') => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 0, 0)', offset: 0},
+      {transform: 'skewX(-12.5deg) skewY(-12.5deg)', offset: 0.222},
+      {transform: 'skewX(6.25deg) skewY(6.25deg)', offset: 0.333},
+      {transform: 'skewX(-3.125deg) skewY(-3.125deg)', offset: 0.444},
+      {transform: 'skewX(1.5625deg) skewY(1.5625deg)', offset: 0.555},
+      {transform: 'skewX(-0.78125deg) skewY(-0.78125deg)', offset: 0.666},
+      {transform: 'skewX(0.390625deg) skewY(0.390625deg)', offset: 0.777},
+      {transform: 'skewX(-0.1953125deg) skewY(-0.1953125deg)', offset: 0.888},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const pulse = (duration = 1000, iterations = Infinity, easing = 'ease-in-out') => {
+  return {
+    keyframes: [
+      {transform: 'scale3d(1, 1, 1)', offset: 0},
+      {transform: 'scale3d(1.05, 1.05, 1.05)', offset: 0.5},
+      {transform: 'scale3d(1, 1, 1)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const rubberBand = (duration = 1000, iterations = 1, easing = 'ease-in-out') => {
+  return {
+    keyframes: [
+      {transform: 'scale3d(1, 1, 1)', offset: 0},
+      {transform: 'scale3d(1.25, 0.75, 1)', offset: 0.3},
+      {transform: 'scale3d(0.75, 1.25, 1)', offset: 0.4},
+      {transform: 'scale3d(1.15, 0.85, 1)', offset: 0.5},
+      {transform: 'scale3d(0.95, 1.05, 1)', offset: 0.65},
+      {transform: 'scale3d(1.05, 0.95, 1)', offset: 0.75},
+      {transform: 'scale3d(1, 1, 1)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const shake = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 0, 0)', offset: 0},
+      {transform: 'translate3d(-10px, 0, 0)', offset: 0.1},
+      {transform: 'translate3d(10px, 0, 0)', offset: 0.2},
+      {transform: 'translate3d(-10px, 0, 0)', offset: 0.3},
+      {transform: 'translate3d(10px, 0, 0)', offset: 0.4},
+      {transform: 'translate3d(-10px, 0, 0)', offset: 0.5},
+      {transform: 'translate3d(10px, 0, 0)', offset: 0.6},
+      {transform: 'translate3d(-10px, 0, 0)', offset: 0.7},
+      {transform: 'translate3d(10px, 0, 0)', offset: 0.8},
+      {transform: 'translate3d(-10px, 0, 0)', offset: 0.9},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const shakeX = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 0, 0)', offset: 0},
+      {transform: 'translate3d(-10px, 0, 0)', offset: 0.1},
+      {transform: 'translate3d(10px, 0, 0)', offset: 0.2},
+      {transform: 'translate3d(-10px, 0, 0)', offset: 0.3},
+      {transform: 'translate3d(10px, 0, 0)', offset: 0.4},
+      {transform: 'translate3d(-10px, 0, 0)', offset: 0.5},
+      {transform: 'translate3d(10px, 0, 0)', offset: 0.6},
+      {transform: 'translate3d(-10px, 0, 0)', offset: 0.7},
+      {transform: 'translate3d(10px, 0, 0)', offset: 0.8},
+      {transform: 'translate3d(-10px, 0, 0)', offset: 0.9},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const shakeY = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 0, 0)', offset: 0},
+      {transform: 'translate3d(0, -10px, 0)', offset: 0.1},
+      {transform: 'translate3d(0, 10px, 0)', offset: 0.2},
+      {transform: 'translate3d(0, -10px, 0)', offset: 0.3},
+      {transform: 'translate3d(0, 10px, 0)', offset: 0.4},
+      {transform: 'translate3d(0, -10px, 0)', offset: 0.5},
+      {transform: 'translate3d(0, 10px, 0)', offset: 0.6},
+      {transform: 'translate3d(0, -10px, 0)', offset: 0.7},
+      {transform: 'translate3d(0, 10px, 0)', offset: 0.8},
+      {transform: 'translate3d(0, -10px, 0)', offset: 0.9},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const swing = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'rotate3d(0, 0, 1, 0deg)', offset: 0}, // Equivalent to `from`
+      {transform: 'rotate3d(0, 0, 1, 15deg)', offset: 0.2},
+      {transform: 'rotate3d(0, 0, 1, -10deg)', offset: 0.4},
+      {transform: 'rotate3d(0, 0, 1, 5deg)', offset: 0.6},
+      {transform: 'rotate3d(0, 0, 1, -5deg)', offset: 0.8},
+      {transform: 'rotate3d(0, 0, 1, 0deg)', offset: 1}, // Equivalent to `to`
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const tada = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'scale3d(1, 1, 1)', offset: 0},
+      {transform: 'scale3d(0.9, 0.9, 0.9) rotate3d(0, 0, 1, -3deg)', offset: 0.1},
+      {transform: 'scale3d(0.9, 0.9, 0.9) rotate3d(0, 0, 1, -3deg)', offset: 0.2},
+      {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)', offset: 0.3},
+      {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg)', offset: 0.4},
+      {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)', offset: 0.5},
+      {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg)', offset: 0.6},
+      {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)', offset: 0.7},
+      {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, -3deg)', offset: 0.8},
+      {transform: 'scale3d(1.1, 1.1, 1.1) rotate3d(0, 0, 1, 3deg)', offset: 0.9},
+      {transform: 'scale3d(1, 1, 1)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const wobble = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 0, 0)', offset: 0}, // Equivalent to `from`
+      {transform: 'translate3d(-25%, 0, 0) rotate3d(0, 0, 1, -5deg)', offset: 0.15},
+      {transform: 'translate3d(20%, 0, 0) rotate3d(0, 0, 1, 3deg)', offset: 0.3},
+      {transform: 'translate3d(-15%, 0, 0) rotate3d(0, 0, 1, -3deg)', offset: 0.45},
+      {transform: 'translate3d(10%, 0, 0) rotate3d(0, 0, 1, 2deg)', offset: 0.6},
+      {transform: 'translate3d(-5%, 0, 0) rotate3d(0, 0, 1, -1deg)', offset: 0.75},
+      {transform: 'translate3d(0, 0, 0)', offset: 1}, // Equivalent to `to`
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+module.exports = {
+  bounce,
+  flash,
+  headShake,
+  heartBeat,
+  jello,
+  pulse,
+  rubberBand,
+  shake,
+  shakeX,
+  shakeY,
+  swing,
+  tada,
+  wobble,
+};

--- a/js/keyframes/back-in.js
+++ b/js/keyframes/back-in.js
@@ -1,0 +1,62 @@
+const backInDown = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'translateY(-1200px) scale(0.7)', opacity: 0.7, offset: 0},
+      {transform: 'translateY(0px) scale(0.7)', opacity: 0.7, offset: 0.8},
+      {transform: 'scale(1)', opacity: 1, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const backInLeft = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'translateX(-2000px) scale(0.7)', opacity: 0.7, offset: 0},
+      {transform: 'translateX(0px) scale(0.7)', opacity: 0.7, offset: 0.8},
+      {transform: 'scale(1)', opacity: 1, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const backInRight = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'translateX(2000px) scale(0.7)', opacity: 0.7, offset: 0},
+      {transform: 'translateX(0px) scale(0.7)', opacity: 0.7, offset: 0.8},
+      {transform: 'scale(1)', opacity: 1, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const backInUp = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'translateY(1200px) scale(0.7)', opacity: 0.7, offset: 0},
+      {transform: 'translateY(0px) scale(0.7)', opacity: 0.7, offset: 0.8},
+      {transform: 'scale(1)', opacity: 1, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+module.exports = {
+  backInDown,
+  backInLeft,
+  backInRight,
+  backInUp,
+};

--- a/js/keyframes/back-out.js
+++ b/js/keyframes/back-out.js
@@ -1,0 +1,62 @@
+const backOutDown = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'scale(1)', opacity: 1, offset: 0},
+      {transform: 'translateY(0px) scale(0.7)', opacity: 0.7, offset: 0.2},
+      {transform: 'translateY(700px) scale(0.7)', opacity: 0.7, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const backOutLeft = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'scale(1)', opacity: 1, offset: 0},
+      {transform: 'translateX(0px) scale(0.7)', opacity: 0.7, offset: 0.2},
+      {transform: 'translateX(-2000px) scale(0.7)', opacity: 0.7, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const backOutRight = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'scale(1)', opacity: 1, offset: 0},
+      {transform: 'translateX(0px) scale(0.7)', opacity: 0.7, offset: 0.2},
+      {transform: 'translateX(2000px) scale(0.7)', opacity: 0.7, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const backOutUp = (duration = 1000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'scale(1)', opacity: 1, offset: 0},
+      {transform: 'translateY(0px) scale(0.7)', opacity: 0.7, offset: 0.2},
+      {transform: 'translateY(-700px) scale(0.7)', opacity: 0.7, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+module.exports = {
+  backOutDown,
+  backOutLeft,
+  backOutRight,
+  backOutUp,
+};

--- a/js/keyframes/bounce-in.js
+++ b/js/keyframes/bounce-in.js
@@ -1,0 +1,108 @@
+const bounceIn = (
+  duration = 1000,
+  easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'scale3d(0.3, 0.3, 0.3)', offset: 0},
+      {transform: 'scale3d(1.1, 1.1, 1.1)', offset: 0.2},
+      {transform: 'scale3d(0.9, 0.9, 0.9)', offset: 0.4},
+      {opacity: 1, transform: 'scale3d(1.03, 1.03, 1.03)', offset: 0.6},
+      {transform: 'scale3d(0.97, 0.97, 0.97)', offset: 0.8},
+      {opacity: 1, transform: 'scale3d(1, 1, 1)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const bounceInDown = (
+  duration = 1000,
+  easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(0, -3000px, 0) scaleY(3)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 25px, 0) scaleY(0.9)', offset: 0.6},
+      {transform: 'translate3d(0, -10px, 0) scaleY(0.95)', offset: 0.75},
+      {transform: 'translate3d(0, 5px, 0) scaleY(0.985)', offset: 0.9},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const bounceInLeft = (
+  duration = 1000,
+  easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(-3000px, 0, 0) scaleX(3)', offset: 0},
+      {opacity: 1, transform: 'translate3d(25px, 0, 0) scaleX(1)', offset: 0.6},
+      {transform: 'translate3d(-10px, 0, 0) scaleX(0.98)', offset: 0.75},
+      {transform: 'translate3d(5px, 0, 0) scaleX(0.995)', offset: 0.9},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const bounceInRight = (
+  duration = 1000,
+  easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(3000px, 0, 0) scaleX(3)', offset: 0},
+      {opacity: 1, transform: 'translate3d(-25px, 0, 0) scaleX(1)', offset: 0.6},
+      {transform: 'translate3d(10px, 0, 0) scaleX(0.98)', offset: 0.75},
+      {transform: 'translate3d(-5px, 0, 0) scaleX(0.995)', offset: 0.9},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const bounceInUp = (
+  duration = 1000,
+  easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(0, 3000px, 0) scaleY(5)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, -20px, 0) scaleY(0.9)', offset: 0.6},
+      {transform: 'translate3d(0, 10px, 0) scaleY(0.95)', offset: 0.75},
+      {transform: 'translate3d(0, -5px, 0) scaleY(0.985)', offset: 0.9},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+module.exports = {
+  bounceIn,
+  bounceInDown,
+  bounceInLeft,
+  bounceInRight,
+  bounceInUp,
+};

--- a/js/keyframes/bounce-out.js
+++ b/js/keyframes/bounce-out.js
@@ -1,0 +1,95 @@
+const bounceOut = (
+  duration = 1000,
+  easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {transform: 'scale3d(0.9, 0.9, 0.9)', offset: 0.2},
+      {opacity: 1, transform: 'scale3d(1.1, 1.1, 1.1)', offset: 0.55},
+      {opacity: 0, transform: 'scale3d(0.3, 0.3, 0.3)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const bounceOutDown = (
+  duration = 1000,
+  easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 10px, 0) scaleY(0.985)', offset: 0.2},
+      {opacity: 1, transform: 'translate3d(0, -20px, 0) scaleY(0.9)', offset: 0.45},
+      {opacity: 0, transform: 'translate3d(0, 2000px, 0) scaleY(3)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const bounceOutLeft = (
+  duration = 1000,
+  easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(20px, 0, 0) scaleX(0.9)', offset: 0.2},
+      {opacity: 0, transform: 'translate3d(-2000px, 0, 0) scaleX(2)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const bounceOutRight = (
+  duration = 1000,
+  easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(-20px, 0, 0) scaleX(0.9)', offset: 0.2},
+      {opacity: 0, transform: 'translate3d(2000px, 0, 0) scaleX(2)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const bounceOutUp = (
+  duration = 1000,
+  easing = 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, -10px, 0) scaleY(0.985)', offset: 0.2},
+      {opacity: 1, transform: 'translate3d(0, 20px, 0) scaleY(0.9)', offset: 0.4},
+      {opacity: 1, transform: 'translate3d(0, 20px, 0) scaleY(0.9)', offset: 0.45},
+      {opacity: 0, transform: 'translate3d(0, -2000px, 0) scaleY(3)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+module.exports = {
+  bounceOutDown,
+  bounceOutLeft,
+  bounceOutRight,
+  bounceOutUp,
+};

--- a/js/keyframes/fade-in.js
+++ b/js/keyframes/fade-in.js
@@ -1,0 +1,184 @@
+const fadeIn = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, offset: 0},
+      {opacity: 1, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInBottomLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(-100%, 100%, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInBottomRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(100%, 100%, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInDown = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(0, -100%, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInDownBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(0, -2000px, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(-100%, 0, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInLeftBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(-2000px, 0, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(100%, 0, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInRightBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(2000px, 0, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInTopLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(-100%, -100%, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInTopRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(100%, -100%, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInUp = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(0, 100%, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeInUpBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(0, 2000px, 0)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+module.exports = {
+  fadeIn,
+  fadeInBottomLeft,
+  fadeInBottomRight,
+  fadeInDown,
+  fadeInDownBig,
+  fadeInLeft,
+  fadeInLeftBig,
+  fadeInRight,
+  fadeInRightBig,
+  fadeInTopLeft,
+  fadeInTopRight,
+  fadeInUp,
+  fadeInUpBig,
+};

--- a/js/keyframes/fade-out.js
+++ b/js/keyframes/fade-out.js
@@ -1,0 +1,184 @@
+const fadeOut = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, offset: 0},
+      {opacity: 0, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutBottomLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(-100%, 100%, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutBottomRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(100%, 100%, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutDown = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(0, 100%, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutDownBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(0, 2000px, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(-100%, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutLeftBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(-2000px, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(100%, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutRightBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(2000px, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutTopLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(-100%, -100%, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutTopRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(100%, -100%, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutUp = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(0, -100%, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const fadeOutUpBig = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0},
+      {opacity: 0, transform: 'translate3d(0, -2000px, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+module.exports = {
+  fadeOut,
+  fadeOutBottomLeft,
+  fadeOutBottomRight,
+  fadeOutDown,
+  fadeOutDownBig,
+  fadeOutLeft,
+  fadeOutLeftBig,
+  fadeOutRight,
+  fadeOutRightBig,
+  fadeOutTopLeft,
+  fadeOutTopRight,
+  fadeOutUp,
+  fadeOutUpBig,
+};

--- a/js/keyframes/flippers.js
+++ b/js/keyframes/flippers.js
@@ -1,0 +1,118 @@
+const flip = (duration = 1000, easing = 'ease-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {
+        transform:
+          'perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 0) rotate3d(0, 1, 0, -360deg)',
+        offset: 0,
+        easing: 'ease-out',
+      },
+      {
+        transform:
+          'perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 150px) rotate3d(0, 1, 0, -190deg)',
+        offset: 0.4,
+        easing: 'ease-out',
+      },
+      {
+        transform:
+          'perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 150px) rotate3d(0, 1, 0, -170deg)',
+        offset: 0.5,
+        easing: 'ease-in',
+      },
+      {
+        transform:
+          'perspective(400px) scale3d(0.95, 0.95, 0.95) translate3d(0, 0, 0) rotate3d(0, 1, 0, 0deg)',
+        offset: 0.8,
+        easing: 'ease-in',
+      },
+      {
+        transform:
+          'perspective(400px) scale3d(1, 1, 1) translate3d(0, 0, 0) rotate3d(0, 1, 0, 0deg)',
+        offset: 1,
+        easing: 'ease-in',
+      },
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const flipInX = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+  return {
+    keyframes: [
+      {
+        transform: 'perspective(400px) rotate3d(1, 0, 0, 90deg)',
+        opacity: 0,
+        offset: 0,
+        easing: 'ease-in',
+      },
+      {transform: 'perspective(400px) rotate3d(1, 0, 0, -20deg)', offset: 0.4, easing: 'ease-in'},
+      {transform: 'perspective(400px) rotate3d(1, 0, 0, 10deg)', opacity: 1, offset: 0.6},
+      {transform: 'perspective(400px) rotate3d(1, 0, 0, -5deg)', offset: 0.8},
+      {transform: 'perspective(400px)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const flipInY = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+  return {
+    keyframes: [
+      {
+        transform: 'perspective(400px) rotate3d(0, 1, 0, 90deg)',
+        opacity: 0,
+        offset: 0,
+        easing: 'ease-in',
+      },
+      {transform: 'perspective(400px) rotate3d(0, 1, 0, -20deg)', offset: 0.4, easing: 'ease-in'},
+      {transform: 'perspective(400px) rotate3d(0, 1, 0, 10deg)', opacity: 1, offset: 0.6},
+      {transform: 'perspective(400px) rotate3d(0, 1, 0, -5deg)', offset: 0.8},
+      {transform: 'perspective(400px)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const flipOutX = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'perspective(400px)', offset: 0},
+      {transform: 'perspective(400px) rotate3d(1, 0, 0, -20deg)', opacity: 1, offset: 0.3},
+      {transform: 'perspective(400px) rotate3d(1, 0, 0, 90deg)', opacity: 0, offset: 1},
+    ],
+    config: {
+      duration: duration * 0.75,
+      easing,
+      iterations,
+    },
+  };
+};
+const flipOutY = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'perspective(400px)', offset: 0},
+      {transform: 'perspective(400px) rotate3d(0, 1, 0, -15deg)', opacity: 1, offset: 0.3},
+      {transform: 'perspective(400px) rotate3d(0, 1, 0, 90deg)', opacity: 0, offset: 1},
+    ],
+    config: {
+      duration: duration * 0.75,
+      easing,
+      iterations,
+    },
+  };
+};
+module.exports = {
+  flip,
+  flipInX,
+  flipInY,
+  flipOutX,
+  flipOutY,
+};

--- a/js/keyframes/lightspeed.js
+++ b/js/keyframes/lightspeed.js
@@ -1,0 +1,62 @@
+const lightSpeedInLeft = (duration = 1000, easing = 'ease-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(-100%, 0, 0) skewX(30deg)', opacity: 0, offset: 0},
+      {transform: 'skewX(-20deg)', opacity: 1, offset: 0.6},
+      {transform: 'skewX(5deg)', offset: 0.8},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const lightSpeedInRight = (duration = 1000, easing = 'ease-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(100%, 0, 0) skewX(-30deg)', opacity: 0, offset: 0},
+      {transform: 'skewX(20deg)', opacity: 1, offset: 0.6},
+      {transform: 'skewX(-5deg)', offset: 0.8},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const lightSpeedOutLeft = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, offset: 0},
+      {transform: 'translate3d(-100%, 0, 0) skewX(-30deg)', opacity: 0, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const lightSpeedOutRight = (duration = 1000, easing = 'ease-in', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, offset: 0},
+      {transform: 'translate3d(100%, 0, 0) skewX(30deg)', opacity: 0, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+module.exports = {
+  lightSpeedInLeft,
+  lightSpeedInRight,
+  lightSpeedOutLeft,
+  lightSpeedOutRight,
+};

--- a/js/keyframes/rotate-in.js
+++ b/js/keyframes/rotate-in.js
@@ -1,0 +1,72 @@
+const rotateIn = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'rotate3d(0, 0, 1, -200deg)', opacity: 0, offset: 0},
+      {transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const rotateInDownLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'rotate3d(0, 0, 1, -45deg)', opacity: 0, offset: 0},
+      {transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const rotateInDownRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'rotate3d(0, 0, 1, 45deg)', opacity: 0, offset: 0},
+      {transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const rotateInUpLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'rotate3d(0, 0, 1, 45deg)', opacity: 0, offset: 0},
+      {transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const rotateInUpRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'rotate3d(0, 0, 1, -90deg)', opacity: 0, offset: 0},
+      {transform: 'translate3d(0, 0, 0)', opacity: 1, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+module.exports = {
+  rotateIn,
+  rotateInDownLeft,
+  rotateInDownRight,
+  rotateInUpLeft,
+  rotateInUpRight,
+};

--- a/js/keyframes/rotate-out.js
+++ b/js/keyframes/rotate-out.js
@@ -1,0 +1,72 @@
+const rotateOut = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {opacity: 1, offset: 0},
+      {transform: 'rotate3d(0, 0, 1, 200deg)', opacity: 0, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const rotateOutDownLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {opacity: 1, offset: 0},
+      {transform: 'rotate3d(0, 0, 1, 45deg)', opacity: 0, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const rotateOutDownRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {opacity: 1, offset: 0},
+      {transform: 'rotate3d(0, 0, 1, -45deg)', opacity: 0, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const rotateOutUpLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {opacity: 1, offset: 0},
+      {transform: 'rotate3d(0, 0, 1, -45deg)', opacity: 0, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const rotateOutUpRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {opacity: 1, offset: 0},
+      {transform: 'rotate3d(0, 0, 1, 90deg)', opacity: 0, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+module.exports = {
+  rotateOut,
+  rotateOutDownLeft,
+  rotateOutDownRight,
+  rotateOutUpLeft,
+  rotateOutUpRight,
+};

--- a/js/keyframes/slide-in.js
+++ b/js/keyframes/slide-in.js
@@ -1,0 +1,58 @@
+const slideInDown = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, -100%, 0)', visibility: 'visible', offset: 0},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const slideInLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(-100%, 0, 0)', visibility: 'visible', offset: 0},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const slideInRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(100%, 0, 0)', visibility: 'visible', offset: 0},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const slideInUp = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 100%, 0)', visibility: 'visible', offset: 0},
+      {transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+module.exports = {
+  slideInDown,
+  slideInLeft,
+  slideInRight,
+  slideInUp,
+};

--- a/js/keyframes/slide-out.js
+++ b/js/keyframes/slide-out.js
@@ -1,0 +1,58 @@
+const slideOutDown = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 0, 0)', offset: 0},
+      {visibility: 'hidden', transform: 'translate3d(0, 100%, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const slideOutLeft = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 0, 0)', offset: 0},
+      {visibility: 'hidden', transform: 'translate3d(-100%, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const slideOutRight = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 0, 0)', offset: 0},
+      {visibility: 'hidden', transform: 'translate3d(100%, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const slideOutUp = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {transform: 'translate3d(0, 0, 0)', offset: 0},
+      {visibility: 'hidden', transform: 'translate3d(0, -100%, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+module.exports = {
+  slideOutDown,
+  slideOutLeft,
+  slideOutRight,
+  slideOutUp,
+};

--- a/js/keyframes/specials.js
+++ b/js/keyframes/specials.js
@@ -40,7 +40,6 @@ const jackInTheBox = (duration = 1000, iterations = 1, easing = 'ease') => {
     ],
     config: {
       duration,
-      easing,
       iterations,
     },
   };

--- a/js/keyframes/specials.js
+++ b/js/keyframes/specials.js
@@ -1,0 +1,79 @@
+const hinge = (duration = 2000, easing = 'ease-in-out', iterations = 1) => {
+  return {
+    keyframes: [
+      {offset: 0, animationTimingFunction: easing},
+      {transform: 'rotate3d(0, 0, 1, 80deg)', offset: 0.2, animationTimingFunction: easing},
+      {
+        transform: 'rotate3d(0, 0, 1, 60deg)',
+        offset: 0.4,
+        opacity: 1,
+        animationTimingFunction: easing,
+      },
+      {
+        transform: 'rotate3d(0, 0, 1, 60deg)',
+        offset: 0.6,
+        opacity: 1,
+        animationTimingFunction: easing,
+      },
+      {transform: 'rotate3d(0, 0, 1, 80deg)', offset: 0.8, animationTimingFunction: easing},
+      {transform: 'translate3d(0, 700px, 0)', opacity: 0, offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const jackInTheBox = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {
+        opacity: 0,
+        transform: 'scale(0.1) rotate(30deg)',
+        transformOrigin: 'center bottom',
+        offset: 0,
+      },
+      {transform: 'rotate(-10deg)', offset: 0.5},
+      {transform: 'rotate(3deg)', offset: 0.7},
+      {opacity: 1, transform: 'scale(1)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const rollIn = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'translate3d(-100%, 0, 0) rotate3d(0, 0, 1, -120deg)', offset: 0},
+      {opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const rollOut = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'translate3d(0, 0, 0) rotate3d(0, 0, 1, 0deg)', offset: 0},
+      {opacity: 0, transform: 'translate3d(100%, 0, 0) rotate3d(0, 0, 1, 120deg)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+module.exports = {
+  hinge,
+  jackInTheBox,
+  rollIn,
+  rollOut,
+};

--- a/js/keyframes/zoom-in.js
+++ b/js/keyframes/zoom-in.js
@@ -1,0 +1,149 @@
+const zoomIn = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {opacity: 0, transform: 'scale3d(0.3, 0.3, 0.3)', offset: 0},
+      {opacity: 1, transform: 'scale3d(1, 1, 1)', offset: 0.5},
+      {opacity: 1, transform: 'scale3d(1, 1, 1)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const zoomInDown = (
+  duration = 1000,
+  easingIn = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+  easingOut = 'cubic-bezier(0.175, 0.885, 0.32, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {
+        opacity: 0,
+        transform: 'scale3d(0.1, 0.1, 0.1) translate3d(0, -1000px, 0)',
+        offset: 0,
+        easing: easingIn,
+      },
+      {
+        opacity: 1,
+        transform: 'scale3d(0.475, 0.475, 0.475) translate3d(0, 60px, 0)',
+        offset: 0.6,
+        easing: easingOut,
+      },
+      {
+        opacity: 1,
+        transform: 'scale3d(1, 1, 1) translate3d(0, 0, 0)',
+        offset: 1,
+      },
+    ],
+    config: {
+      duration,
+      iterations,
+    },
+  };
+};
+const zoomInLeft = (
+  duration = 1000,
+  easingIn = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+  easingOut = 'cubic-bezier(0.175, 0.885, 0.32, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {
+        opacity: 0,
+        transform: 'scale3d(0.1, 0.1, 0.1) translate3d(-1000px, 0, 0)',
+        offset: 0,
+        easing: easingIn,
+      },
+      {
+        opacity: 1,
+        transform: 'scale3d(0.475, 0.475, 0.475) translate3d(10px, 0, 0)',
+        offset: 0.6,
+        easing: easingOut,
+      },
+      {
+        opacity: 1,
+        transform: 'scale3d(1, 1, 1) translate3d(0, 0, 0)',
+        offset: 1,
+      },
+    ],
+    config: {
+      duration,
+      iterations,
+    },
+  };
+};
+const zoomInRight = (
+  duration = 1000,
+  easingIn = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+  easingOut = 'cubic-bezier(0.175, 0.885, 0.32, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {
+        opacity: 0,
+        transform: 'scale3d(0.1, 0.1, 0.1) translate3d(1000px, 0, 0)',
+        offset: 0,
+        easing: easingIn,
+      },
+      {
+        opacity: 1,
+        transform: 'scale3d(0.475, 0.475, 0.475) translate3d(-10px, 0, 0)',
+        offset: 0.6,
+        easing: easingOut,
+      },
+      {
+        opacity: 1,
+        transform: 'scale3d(1, 1, 1) translate3d(0, 0, 0)',
+        offset: 1,
+      },
+    ],
+    config: {
+      duration,
+      iterations,
+    },
+  };
+};
+const zoomInUp = (
+  duration = 1000,
+  easingIn = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+  easingOut = 'cubic-bezier(0.175, 0.885, 0.32, 1)',
+  iterations = 1,
+) => {
+  return {
+    keyframes: [
+      {
+        opacity: 0,
+        transform: 'scale3d(0.1, 0.1, 0.1) translate3d(0, 1000px, 0)',
+        offset: 0,
+        easing: easingIn,
+      },
+      {
+        opacity: 1,
+        transform: 'scale3d(0.475, 0.475, 0.475) translate3d(0, -60px, 0)',
+        offset: 0.6,
+        easing: easingOut,
+      },
+      {
+        opacity: 1,
+        transform: 'scale3d(1, 1, 1) translate3d(0, 0, 0)',
+        offset: 1,
+      },
+    ],
+    config: {
+      duration,
+      iterations,
+    },
+  };
+};
+module.exports = {
+  zoomIn,
+  zoomInDown,
+  zoomInLeft,
+  zoomInRight,
+  zoomInUp,
+};

--- a/js/keyframes/zoom-out.js
+++ b/js/keyframes/zoom-out.js
@@ -1,0 +1,106 @@
+const zoomOut = (duration = 1000, iterations = 1, easing = 'ease') => {
+  return {
+    keyframes: [
+      {
+        opacity: 1,
+        transform: 'scale3d(1, 1, 1)',
+        offset: 0,
+      },
+      {
+        opacity: 0,
+        transform: 'scale3d(0.3, 0.3, 0.3)',
+        offset: 0.5,
+      },
+      {
+        opacity: 0,
+        transform: 'scale3d(0.3, 0.3, 0.3)',
+        offset: 1,
+      },
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+  };
+};
+const zoomOutDown = (
+  duration = 1000,
+  iterations = 1,
+  easingIn = 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+  easingOut = 'cubic-bezier(0.175, 0.885, 0.32, 1)',
+) => {
+  return {
+    keyframes: [
+      {
+        opacity: 1,
+        transform: 'scale3d(0.475, 0.475, 0.475) translate3d(0, -60px, 0)',
+        offset: 0.4,
+        easing: easingIn,
+      },
+      {
+        opacity: 0,
+        transform: 'scale3d(0.1, 0.1, 0.1) translate3d(0, 2000px, 0)',
+        offset: 1,
+        easing: easingOut,
+      },
+    ],
+    config: {
+      duration,
+      iterations,
+    },
+  };
+};
+const zoomOutLeft = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'scale3d(0.475, 0.475, 0.475) translate3d(42px, 0, 0)', offset: 0.4},
+      {opacity: 0, transform: 'scale(0.1) translate3d(-2000px, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+    transformOrigin: 'left center',
+  };
+};
+const zoomOutRight = (duration = 1000, easing = 'linear', iterations = 1) => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'scale3d(0.475, 0.475, 0.475) translate3d(-42px, 0, 0)', offset: 0.4},
+      {opacity: 0, transform: 'scale(0.1) translate3d(2000px, 0, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+    transformOrigin: 'right center',
+  };
+};
+const zoomOutUp = (duration = 1000, iterations = 1, easing = 'linear') => {
+  return {
+    keyframes: [
+      {opacity: 1, transform: 'scale3d(0.475, 0.475, 0.475) translate3d(0, 60px, 0)', offset: 0.4},
+      {opacity: 0, transform: 'scale3d(0.1, 0.1, 0.1) translate3d(0, -2000px, 0)', offset: 1},
+    ],
+    config: {
+      duration,
+      easing,
+      iterations,
+    },
+    transformOrigin: 'center bottom',
+    timingFunction: [
+      'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+      'cubic-bezier(0.175, 0.885, 0.32, 1)',
+    ],
+  };
+};
+module.exports = {
+  zoomOut,
+  zoomOutDown,
+  zoomOutLeft,
+  zoomOutRight,
+  zoomOutUp,
+};

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
   ],
   "exports": {
     "./js": {
-      "import": "./js/index.js"
+      "import": "./animate-css.mjs",
+      "require": "./animate-css.cjs"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "docs": "npm-run-all docs:library docs:pages",
     "version": "npm-run-all start docs && git add -A docs animate.css animate.min.css animate.compat.css",
     "postversion": "git push && git push --tags",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "dev-js": "rollup -c rollup.config.js -w",
+    "build-js": "rollup -c rollup.config.js"
   },
   "browserslist": [
     "> 3%",
@@ -42,6 +44,8 @@
     }
   },
   "devDependencies": {
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-terser": "^0.4.4",
     "autoprefixer": "^10.4.7",
     "cssnano": "^5.0.17",
     "eslint": "^7.32.0",
@@ -53,7 +57,7 @@
     "postcss-cli": "^8.3.1",
     "postcss-header": "^3.0.1",
     "postcss-import": "^14.0.2",
-    "postcss-prefixer": "^2.1.3",
+    "postcss-prefixer": "^3.0.0",
     "postcss-preset-env": "^6.7.0",
     "prettier": "^2.7.1"
   },
@@ -64,6 +68,12 @@
     "animate.compat.css",
     "animate.min.css",
     "animate.css",
-    "source/**/*.css"
-  ]
+    "source/**/*.css",
+    "js/**/*.js"
+  ],
+  "exports": {
+    "./js": {
+      "import": "./js/index.js"
+    }
+  }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,29 @@
+const commonjs = require('@rollup/plugin-commonjs');
+const resolve = require('@rollup/plugin-node-resolve');
+const terser = require('@rollup/plugin-terser');
+
+module.exports = {
+  input: 'js/index.js',
+  output: [
+    {
+      file: 'animate-css.cjs',
+      format: 'cjs',
+    },
+    {
+      file: 'animate-css.mjs',
+      format: 'es',
+    },
+    {
+      file: 'animate-css.js',
+      format: 'umd',
+      name: 'AnimateCss',
+    },
+    {
+      file: 'animate-css.min.js',
+      format: 'umd',
+      name: 'AnimateCss',
+      plugins: [terser()],
+    },
+  ],
+  plugins: [resolve(), commonjs()],
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,21 +2,21 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@7.12.11", "@babel/code-frame@^7.0.0":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@7.12.11":
   version "7.12.11"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
+  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz"
   integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
   dependencies:
     "@babel/highlight" "^7.10.4"
 
 "@babel/helper-validator-identifier@^7.10.4":
   version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
+  resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz"
   integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
 
 "@babel/highlight@^7.10.4":
   version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.4.tgz#7d1bdfd65753538fabe6c38596cdb76d9ac60143"
+  resolved "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz"
   integrity sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
@@ -25,12 +25,12 @@
 
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
+  resolved "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.3.tgz#9e42981ef035beb3dd49add17acb96e8ff6f394c"
+  resolved "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz"
   integrity sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==
   dependencies:
     ajv "^6.12.4"
@@ -45,7 +45,7 @@
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
+  resolved "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz"
   integrity sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==
   dependencies:
     "@humanwhocodes/object-schema" "^1.2.0"
@@ -54,58 +54,143 @@
 
 "@humanwhocodes/object-schema@^1.2.0":
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz#87de7af9c231826fdd68ac7258f77c429e0e5fcf"
+  resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz"
   integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
+
+"@jridgewell/gen-mapping@^0.3.5":
+  version "0.3.5"
+  resolved "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz"
+  integrity sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==
+  dependencies:
+    "@jridgewell/set-array" "^1.2.1"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
+"@jridgewell/resolve-uri@^3.1.0":
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz"
+  integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
+
+"@jridgewell/set-array@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz"
+  integrity sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==
+
+"@jridgewell/source-map@^0.3.3":
+  version "0.3.6"
+  resolved "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz"
+  integrity sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.25"
+
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14":
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz"
+  integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
+
+"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
+  version "0.3.25"
+  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz"
+  integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
+  resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz"
   integrity sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==
   dependencies:
     "@nodelib/fs.stat" "2.0.3"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.3", "@nodelib/fs.stat@^2.0.2":
+"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.3":
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz#34dc5f4cabbc720f4e60f75a747e7ecd6c175bd3"
+  resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz"
   integrity sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==
 
 "@nodelib/fs.walk@^1.2.3":
   version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz#011b9202a70a6366e436ca5c065844528ab04976"
+  resolved "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz"
   integrity sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==
   dependencies:
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@rollup/plugin-node-resolve@^15.2.3":
+  version "15.2.3"
+  resolved "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz"
+  integrity sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.1"
+    "@types/resolve" "1.20.2"
+    deepmerge "^4.2.2"
+    is-builtin-module "^3.2.1"
+    is-module "^1.0.0"
+    resolve "^1.22.1"
+
+"@rollup/plugin-terser@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz"
+  integrity sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==
+  dependencies:
+    serialize-javascript "^6.0.1"
+    smob "^1.0.0"
+    terser "^5.17.4"
+
+"@rollup/pluginutils@^5.0.1":
+  version "5.1.0"
+  resolved "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz"
+  integrity sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    estree-walker "^2.0.2"
+    picomatch "^2.3.1"
+
 "@trysound/sax@0.2.0":
   version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
+  resolved "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
 "@types/color-name@^1.1.1":
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
+  resolved "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+"@types/estree@^1.0.0":
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz"
+  integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
+  resolved "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+
+"@types/resolve@1.20.2":
+  version "1.20.2"
+  resolved "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz"
+  integrity sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==
 
 acorn-jsx@^5.3.1:
   version "5.3.1"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
+  resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz"
   integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
 
-acorn@^7.4.0:
+"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^7.4.0:
   version "7.4.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.0.tgz#e1ad486e6c54501634c6c397c5c121daa383607c"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz"
   integrity sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==
+
+acorn@^8.8.2:
+  version "8.12.1"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz"
+  integrity sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==
 
 aggregate-error@^3.0.0:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.1.tgz#db2fe7246e536f40d9b5442a39e117d7dd6a24e0"
+  resolved "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz"
   integrity sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==
   dependencies:
     clean-stack "^2.0.0"
@@ -113,7 +198,7 @@ aggregate-error@^3.0.0:
 
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.4"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.4.tgz#0614facc4522127fa713445c6bfd3ebd376e2234"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz"
   integrity sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==
   dependencies:
     fast-deep-equal "^3.1.1"
@@ -123,7 +208,7 @@ ajv@^6.10.0, ajv@^6.12.4:
 
 ajv@^8.0.1:
   version "8.5.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.5.0.tgz#695528274bcb5afc865446aa275484049a18ae4b"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz"
   integrity sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==
   dependencies:
     fast-deep-equal "^3.1.1"
@@ -133,41 +218,31 @@ ajv@^8.0.1:
 
 ansi-colors@^4.1.1:
   version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
+  resolved "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz"
   integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
 ansi-escapes@^4.3.0:
   version "4.3.1"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.1.tgz#a5c47cc43181f1f38ffd7076837700d395522a61"
+  resolved "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz"
   integrity sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==
   dependencies:
     type-fest "^0.11.0"
 
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
-
 ansi-regex@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
-  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
-
-ansi-styles@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
-  integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^3.2.1:
   version "3.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
 
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz"
   integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
   dependencies:
     "@types/color-name" "^1.1.1"
@@ -175,7 +250,7 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
 
 anymatch@~3.1.1:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
+  resolved "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz"
   integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
   dependencies:
     normalize-path "^3.0.0"
@@ -183,34 +258,34 @@ anymatch@~3.1.1:
 
 argparse@^1.0.7:
   version "1.0.10"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  resolved "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz"
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
 
 argparse@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 array-union@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
+  resolved "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
 astral-regex@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
+  resolved "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
 at-least-node@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  resolved "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
 autoprefixer@^10.4.7:
   version "10.4.7"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.7.tgz#1db8d195f41a52ca5069b7593be167618edbbedf"
+  resolved "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.7.tgz"
   integrity sha512-ypHju4Y2Oav95SipEcCcI5J7CGPuvz8oat7sUtYj3ClK44bldfvtvcxK6IEK++7rqB7YchDGzweZIBG+SD0ZAA==
   dependencies:
     browserslist "^4.20.3"
@@ -222,7 +297,7 @@ autoprefixer@^10.4.7:
 
 autoprefixer@^9.6.1:
   version "9.8.6"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.8.6.tgz#3b73594ca1bf9266320c5acf1588d74dea74210f"
+  resolved "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz"
   integrity sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==
   dependencies:
     browserslist "^4.12.0"
@@ -235,37 +310,37 @@ autoprefixer@^9.6.1:
 
 balanced-match@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
-  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+  resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c= sha512-9Y0g0Q8rmSt+H33DfKv7FOc3v+iRI+o1lbzt8jGcIosYW37IIW/2XVYq5NPdmaD5NQ59Nk26Kl/vZbwW9Fr8vg==
 
 binary-extensions@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
+  resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz"
   integrity sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==
 
 boolbase@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
-  integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+  resolved "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
+  integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24= sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
   integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^3.0.1, braces@~3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
-  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+braces@^3.0.3, braces@~3.0.2:
+  version "3.0.3"
+  resolved "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz"
+  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
-    fill-range "^7.0.1"
+    fill-range "^7.1.1"
 
 browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.16.6, browserslist@^4.20.3, browserslist@^4.6.4:
   version "4.20.3"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.20.3.tgz#eb7572f49ec430e054f56d52ff0ebe9be915f8bf"
+  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz"
   integrity sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==
   dependencies:
     caniuse-lite "^1.0.30001332"
@@ -274,14 +349,24 @@ browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.16.6, browserslist@^4
     node-releases "^2.0.3"
     picocolors "^1.0.0"
 
+buffer-from@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz"
+  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
+builtin-modules@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz"
+  integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
+
 callsites@^3.0.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  resolved "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
 caniuse-api@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-3.0.0.tgz#5e4d90e2274961d46291997df599e3ed008ee4c0"
+  resolved "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz"
   integrity sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==
   dependencies:
     browserslist "^4.0.0"
@@ -291,23 +376,21 @@ caniuse-api@^3.0.0:
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001332, caniuse-lite@^1.0.30001335:
   version "1.0.30001335"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001335.tgz#899254a0b70579e5a957c32dced79f0727c61f2a"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001335.tgz"
   integrity sha512-ddP1Tgm7z2iIxu6QTtbZUv6HJxSaV/PZeSrWFZtbY4JZ69tOeNhBCl3HyRQgeNZKE5AOn1kpV7fhljigy0Ty3w==
 
-chalk@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
-  integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
-  dependencies:
-    ansi-styles "^2.2.1"
-    escape-string-regexp "^1.0.2"
-    has-ansi "^2.0.0"
-    strip-ansi "^3.0.0"
-    supports-color "^2.0.0"
-
-chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.0.0:
   version "2.4.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
+chalk@^2.4.1:
+  version "2.4.2"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
   dependencies:
     ansi-styles "^3.2.1"
@@ -316,7 +399,7 @@ chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
 
 chalk@^4.0.0:
   version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
@@ -324,7 +407,7 @@ chalk@^4.0.0:
 
 chokidar@^3.3.0:
   version "3.4.2"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.2.tgz#38dc8e658dec3809741eb3ef7bb0a47fe424232d"
+  resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz"
   integrity sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==
   dependencies:
     anymatch "~3.1.1"
@@ -339,19 +422,19 @@ chokidar@^3.3.0:
 
 clean-stack@^2.0.0:
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
+  resolved "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
 cli-cursor@^3.1.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
+  resolved "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz"
   integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
   dependencies:
     restore-cursor "^3.1.0"
 
-cli-truncate@2.1.0, cli-truncate@^2.1.0:
+cli-truncate@^2.1.0, cli-truncate@2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
+  resolved "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz"
   integrity sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==
   dependencies:
     slice-ansi "^3.0.0"
@@ -359,7 +442,7 @@ cli-truncate@2.1.0, cli-truncate@^2.1.0:
 
 cliui@^7.0.2:
   version "7.0.4"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  resolved "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz"
   integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
   dependencies:
     string-width "^4.2.0"
@@ -368,56 +451,61 @@ cliui@^7.0.2:
 
 color-convert@^1.9.0:
   version "1.9.3"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  resolved "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
   dependencies:
     color-name "1.1.3"
 
 color-convert@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  resolved "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz"
   integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
   dependencies:
     color-name "~1.1.4"
 
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
-
 color-name@~1.1.4:
   version "1.1.4"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU= sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
 colord@^2.9.1:
   version "2.9.1"
-  resolved "https://registry.yarnpkg.com/colord/-/colord-2.9.1.tgz#c961ea0efeb57c9f0f4834458f26cb9cc4a3f90e"
+  resolved "https://registry.npmjs.org/colord/-/colord-2.9.1.tgz"
   integrity sha512-4LBMSt09vR0uLnPVkOUBnmxgoaeN4ewRbx801wY/bXcltXfpR/G46OdWn96XpYmCWuYvO46aBZP4NgX8HpNAcw==
 
 colorette@^1.2.1, colorette@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.4.0.tgz#5190fbb87276259a86ad700bff2c6d6faa3fca40"
+  resolved "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz"
   integrity sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==
+
+commander@^2.20.0:
+  version "2.20.3"
+  resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 commander@^7.2.0:
   version "7.2.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  resolved "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
 commander@^8.2.0:
   version "8.2.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-8.2.0.tgz#37fe2bde301d87d47a53adeff8b5915db1381ca8"
+  resolved "https://registry.npmjs.org/commander/-/commander-8.2.0.tgz"
   integrity sha512-LLKxDvHeL91/8MIyTAD5BFMNtoIwztGPMiM/7Bl8rIPmHCZXRxmSWr91h57dpOpnQ6jIUqEWdXE/uBYMfiVZDA==
 
 concat-map@0.0.1:
   version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+  resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s= sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
   version "7.0.1"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
+  resolved "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz"
   integrity sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==
   dependencies:
     "@types/parse-json" "^4.0.0"
@@ -428,7 +516,7 @@ cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
 
 cross-spawn@^6.0.5:
   version "6.0.5"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
   dependencies:
     nice-try "^1.0.4"
@@ -439,7 +527,7 @@ cross-spawn@^6.0.5:
 
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
   dependencies:
     path-key "^3.1.0"
@@ -448,21 +536,21 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
 
 css-blank-pseudo@^0.1.4:
   version "0.1.4"
-  resolved "https://registry.yarnpkg.com/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz#dfdefd3254bf8a82027993674ccf35483bfcb3c5"
+  resolved "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz"
   integrity sha512-LHz35Hr83dnFeipc7oqFDmsjHdljj3TQtxGGiNWSOsTLIAubSm4TEz8qCaKFpk7idaQ1GfWscF4E6mgpBysA1w==
   dependencies:
     postcss "^7.0.5"
 
 css-declaration-sorter@^6.0.3:
   version "6.0.3"
-  resolved "https://registry.yarnpkg.com/css-declaration-sorter/-/css-declaration-sorter-6.0.3.tgz#9dfd8ea0df4cc7846827876fafb52314890c21a9"
+  resolved "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.0.3.tgz"
   integrity sha512-52P95mvW1SMzuRZegvpluT6yEv0FqQusydKQPZsNN5Q7hh8EwQvN8E2nwuJ16BBvNN6LcoIZXu/Bk58DAhrrxw==
   dependencies:
     timsort "^0.3.0"
 
 css-has-pseudo@^0.10.0:
   version "0.10.0"
-  resolved "https://registry.yarnpkg.com/css-has-pseudo/-/css-has-pseudo-0.10.0.tgz#3c642ab34ca242c59c41a125df9105841f6966ee"
+  resolved "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-0.10.0.tgz"
   integrity sha512-Z8hnfsZu4o/kt+AuFzeGpLVhFOGO9mluyHBaA2bA8aCGTwah5sT3WV/fTHH8UNZUytOIImuGPrl/prlb4oX4qQ==
   dependencies:
     postcss "^7.0.6"
@@ -470,14 +558,14 @@ css-has-pseudo@^0.10.0:
 
 css-prefers-color-scheme@^3.1.1:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/css-prefers-color-scheme/-/css-prefers-color-scheme-3.1.1.tgz#6f830a2714199d4f0d0d0bb8a27916ed65cff1f4"
+  resolved "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-3.1.1.tgz"
   integrity sha512-MTu6+tMs9S3EUqzmqLXEcgNRbNkkD/TGFvowpeoWJn5Vfq7FMgsmRQs9X5NXAURiOBmOxm/lLjsDNXDE6k9bhg==
   dependencies:
     postcss "^7.0.5"
 
 css-select@^4.1.3:
   version "4.1.3"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.1.3.tgz#a70440f70317f2669118ad74ff105e65849c7067"
+  resolved "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz"
   integrity sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==
   dependencies:
     boolbase "^1.0.0"
@@ -488,7 +576,7 @@ css-select@^4.1.3:
 
 css-selector-tokenizer@^0.7.2:
   version "0.7.3"
-  resolved "https://registry.yarnpkg.com/css-selector-tokenizer/-/css-selector-tokenizer-0.7.3.tgz#735f26186e67c749aaf275783405cf0661fae8f1"
+  resolved "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.3.tgz"
   integrity sha512-jWQv3oCEL5kMErj4wRnK/OPoBi0D+P1FR2cDCKYPaMeD2eW3/mttav8HT4hT1CKopiJI/psEULjkClhvJo4Lvg==
   dependencies:
     cssesc "^3.0.0"
@@ -496,7 +584,7 @@ css-selector-tokenizer@^0.7.2:
 
 css-tree@^1.1.2, css-tree@^1.1.3:
   version "1.1.3"
-  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.3.tgz#eb4870fb6fd7707327ec95c2ff2ab09b5e8db91d"
+  resolved "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz"
   integrity sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==
   dependencies:
     mdn-data "2.0.14"
@@ -504,27 +592,27 @@ css-tree@^1.1.2, css-tree@^1.1.3:
 
 css-what@^5.0.0:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.0.1.tgz#3efa820131f4669a8ac2408f9c32e7c7de9f4cad"
+  resolved "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz"
   integrity sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==
 
 cssdb@^4.4.0:
   version "4.4.0"
-  resolved "https://registry.yarnpkg.com/cssdb/-/cssdb-4.4.0.tgz#3bf2f2a68c10f5c6a08abd92378331ee803cddb0"
+  resolved "https://registry.npmjs.org/cssdb/-/cssdb-4.4.0.tgz"
   integrity sha512-LsTAR1JPEM9TpGhl/0p3nQecC2LJ0kD8X5YARu1hk/9I1gril5vDtMZyNxcEpxxDj34YNck/ucjuoUd66K03oQ==
 
 cssesc@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-2.0.0.tgz#3b13bd1bb1cb36e1bcb5a4dcd27f54c5dcb35703"
+  resolved "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz"
   integrity sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==
 
 cssesc@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
+  resolved "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
 cssnano-preset-default@^5.1.12:
   version "5.1.12"
-  resolved "https://registry.yarnpkg.com/cssnano-preset-default/-/cssnano-preset-default-5.1.12.tgz#64e2ad8e27a279e1413d2d2383ef89a41c909be9"
+  resolved "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.1.12.tgz"
   integrity sha512-rO/JZYyjW1QNkWBxMGV28DW7d98UDLaF759frhli58QFehZ+D/LSmwQ2z/ylBAe2hUlsIWTq6NYGfQPq65EF9w==
   dependencies:
     css-declaration-sorter "^6.0.3"
@@ -559,12 +647,12 @@ cssnano-preset-default@^5.1.12:
 
 cssnano-utils@^3.0.2:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/cssnano-utils/-/cssnano-utils-3.0.2.tgz#d82b4991a27ba6fec644b39bab35fe027137f516"
+  resolved "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.0.2.tgz"
   integrity sha512-KhprijuQv2sP4kT92sSQwhlK3SJTbDIsxcfIEySB0O+3m9esFOai7dP9bMx5enHAh2MwarVIcnwiWoOm01RIbQ==
 
 cssnano@^5.0.17:
   version "5.0.17"
-  resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-5.0.17.tgz#ff45713c05cfc780a1aeb3e663b6f224d091cabf"
+  resolved "https://registry.npmjs.org/cssnano/-/cssnano-5.0.17.tgz"
   integrity sha512-fmjLP7k8kL18xSspeXTzRhaFtRI7DL9b8IcXR80JgtnWBpvAzHT7sCR/6qdn0tnxIaINUN6OEQu83wF57Gs3Xw==
   dependencies:
     cssnano-preset-default "^5.1.12"
@@ -573,78 +661,78 @@ cssnano@^5.0.17:
 
 csso@^4.2.0:
   version "4.2.0"
-  resolved "https://registry.yarnpkg.com/csso/-/csso-4.2.0.tgz#ea3a561346e8dc9f546d6febedd50187cf389529"
+  resolved "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz"
   integrity sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==
   dependencies:
     css-tree "^1.1.2"
 
 debug@^4.0.1, debug@^4.1.1, debug@^4.3.2:
   version "4.3.2"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
   dependencies:
     ms "2.1.2"
 
 deep-is@^0.1.3:
   version "0.1.3"
-  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
-  integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+  resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+  integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ= sha512-GtxAN4HvBachZzm4OnWqc45ESpUCMwkYcsjnsPs23FwJbsO+k4t0k9bQCgOmzIlpHO28+WPK/KRbRk0DDHuuDw==
+
+deepmerge@^4.2.2:
+  version "4.3.1"
+  resolved "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz"
+  integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
 
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
-  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  resolved "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz"
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
   dependencies:
     object-keys "^1.0.12"
 
 dependency-graph@^0.9.0:
   version "0.9.0"
-  resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.9.0.tgz#11aed7e203bc8b00f48356d92db27b265c445318"
+  resolved "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.9.0.tgz"
   integrity sha512-9YLIBURXj4DJMFALxXw9K3Y3rwb5Fk0X5/8ipCzaN84+gKxoHK43tVKRNakCQbiEx07E8Uwhuq21BpUagFhZ8w==
 
 dir-glob@^3.0.1:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
+  resolved "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz"
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
 
 doctrine@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  resolved "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz"
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
 
 dom-serializer@^1.0.1:
   version "1.3.2"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91"
+  resolved "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz"
   integrity sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==
   dependencies:
     domelementtype "^2.0.1"
     domhandler "^4.2.0"
     entities "^2.0.0"
 
-domelementtype@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
-  integrity sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==
-
-domelementtype@^2.2.0:
+domelementtype@^2.0.1, domelementtype@^2.2.0:
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
+  resolved "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz"
   integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
 
 domhandler@^4.2.0:
   version "4.2.0"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.2.0.tgz#f9768a5f034be60a89a27c2e4d0f74eba0d8b059"
+  resolved "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz"
   integrity sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==
   dependencies:
     domelementtype "^2.2.0"
 
 domutils@^2.6.0:
   version "2.7.0"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.7.0.tgz#8ebaf0c41ebafcf55b0b72ec31c56323712c5442"
+  resolved "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz"
   integrity sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==
   dependencies:
     dom-serializer "^1.0.1"
@@ -653,36 +741,36 @@ domutils@^2.6.0:
 
 electron-to-chromium@^1.4.118:
   version "1.4.129"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.129.tgz#c675793885721beefff99da50f57c6525c2cd238"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.129.tgz"
   integrity sha512-GgtN6bsDtHdtXJtlMYZWGB/uOyjZWjmRDumXTas7dGBaB9zUyCjzHet1DY2KhyHN8R0GLbzZWqm4efeddqqyRQ==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-enquirer@^2.3.5, enquirer@^2.3.6:
+enquirer@^2.3.5, enquirer@^2.3.6, "enquirer@>= 2.3.0 < 3":
   version "2.3.6"
-  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
+  resolved "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz"
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
   dependencies:
     ansi-colors "^4.1.1"
 
 entities@^2.0.0, entities@~2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
+  resolved "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz"
   integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
 
 error-ex@^1.3.1:
   version "1.3.2"
-  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
+  resolved "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz"
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.17.0-next.1, es-abstract@^1.17.5:
   version "1.17.6"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.6.tgz#9142071707857b2cacc7b89ecb670316c3e2d52a"
+  resolved "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz"
   integrity sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==
   dependencies:
     es-to-primitive "^1.2.1"
@@ -699,7 +787,7 @@ es-abstract@^1.17.0-next.1, es-abstract@^1.17.5:
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
+  resolved "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz"
   integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
   dependencies:
     is-callable "^1.1.4"
@@ -708,22 +796,22 @@ es-to-primitive@^1.2.1:
 
 escalade@^3.1.1:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  resolved "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.5:
   version "1.0.5"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ= sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 eslint-scope@^5.1.1:
   version "5.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
   dependencies:
     esrecurse "^4.3.0"
@@ -731,24 +819,29 @@ eslint-scope@^5.1.1:
 
 eslint-utils@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
+  resolved "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz"
   integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
+eslint-visitor-keys@^1.1.0:
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
+  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz"
+  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
+
+eslint-visitor-keys@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
 eslint-visitor-keys@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
+  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
 eslint@^7.32.0:
   version "7.32.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.32.0.tgz#c6d328a14be3fb08c8d1d21e12c02fdb7a2a812d"
+  resolved "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz"
   integrity sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==
   dependencies:
     "@babel/code-frame" "7.12.11"
@@ -794,7 +887,7 @@ eslint@^7.32.0:
 
 espree@^7.3.0, espree@^7.3.1:
   version "7.3.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
+  resolved "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz"
   integrity sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==
   dependencies:
     acorn "^7.4.0"
@@ -803,41 +896,51 @@ espree@^7.3.0, espree@^7.3.1:
 
 esprima@^4.0.0:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  resolved "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 esquery@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
+  resolved "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz"
   integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
   dependencies:
     estraverse "^5.1.0"
 
 esrecurse@^4.3.0:
   version "4.3.0"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
+  resolved "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz"
   integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
   dependencies:
     estraverse "^5.2.0"
 
 estraverse@^4.1.1:
   version "4.3.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
+  resolved "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.1.0, estraverse@^5.2.0:
+estraverse@^5.1.0:
   version "5.2.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
+  resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
+
+estraverse@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz"
+  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
+
+estree-walker@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
 esutils@^2.0.2:
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
+  resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
 execa@^5.1.1:
   version "5.1.1"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
+  resolved "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
   dependencies:
     cross-spawn "^7.0.3"
@@ -852,12 +955,12 @@ execa@^5.1.1:
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-glob@^3.1.1:
   version "3.2.4"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.4.tgz#d20aefbf99579383e7f3cc66529158c9b98554d3"
+  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz"
   integrity sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
@@ -869,43 +972,43 @@ fast-glob@^3.1.1:
 
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
+  resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
 fast-levenshtein@^2.0.6:
   version "2.0.6"
-  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
-  integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+  resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
+  integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc= sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fastparse@^1.1.2:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
+  resolved "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz"
   integrity sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==
 
 fastq@^1.6.0:
   version "1.8.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.8.0.tgz#550e1f9f59bbc65fe185cb6a9b4d95357107f481"
+  resolved "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz"
   integrity sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==
   dependencies:
     reusify "^1.0.4"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
+  resolved "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz"
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
 
-fill-range@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
-  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+fill-range@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz"
+  integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
 
 flat-cache@^3.0.4:
   version "3.0.4"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
+  resolved "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz"
   integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
   dependencies:
     flatted "^3.1.0"
@@ -913,22 +1016,22 @@ flat-cache@^3.0.4:
 
 flatted@^3.1.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.0.tgz#a5d06b4a8b01e3a63771daa5cb7a1903e2e57067"
+  resolved "https://registry.npmjs.org/flatted/-/flatted-3.1.0.tgz"
   integrity sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==
 
 flatten@^1.0.2:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
+  resolved "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
 fraction.js@^4.2.0:
   version "4.2.0"
-  resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.2.0.tgz#448e5109a313a3527f5a3ab2119ec4cf0e0e2950"
+  resolved "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz"
   integrity sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==
 
 fs-extra@^9.0.0:
   version "9.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz#910da0062437ba4c39fedd863f1675ccfefcb9fc"
+  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz"
   integrity sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==
   dependencies:
     at-least-node "^1.0.0"
@@ -938,54 +1041,49 @@ fs-extra@^9.0.0:
 
 fs.realpath@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
-  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+  resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8= sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@~2.1.2:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
-  integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
-
-function-bind@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
-  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+function-bind@^1.1.1, function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
-  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+  resolved "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz"
+  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc= sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==
 
 get-caller-file@^2.0.5:
   version "2.0.5"
-  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
+  resolved "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz"
   integrity sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==
 
 get-stdin@^8.0.0:
   version "8.0.0"
-  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-8.0.0.tgz#cbad6a73feb75f6eeb22ba9e01f89aa28aa97a53"
+  resolved "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz"
   integrity sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==
 
 get-stream@^6.0.0:
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
+  resolved "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
 glob-parent@^5.1.0, glob-parent@^5.1.2, glob-parent@~5.1.0:
   version "5.1.2"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
 
 glob@^7.1.3:
   version "7.1.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
@@ -997,14 +1095,14 @@ glob@^7.1.3:
 
 globals@^13.6.0, globals@^13.9.0:
   version "13.9.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.9.0.tgz#4bf2bf635b334a173fb1daf7c5e6b218ecdc06cb"
+  resolved "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz"
   integrity sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==
   dependencies:
     type-fest "^0.20.2"
 
 globby@^11.0.0:
   version "11.0.1"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.1.tgz#9a2bf107a068f3ffeabc49ad702c79ede8cfd357"
+  resolved "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz"
   integrity sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==
   dependencies:
     array-union "^2.1.0"
@@ -1016,78 +1114,73 @@ globby@^11.0.0:
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.4"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
+  resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
-
-has-ansi@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
-  integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
-  dependencies:
-    ansi-regex "^2.0.0"
-
-has-flag@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
-  integrity sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=
 
 has-flag@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
-  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+  resolved "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz"
+  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0= sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
 
 has-flag@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  resolved "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
 has-symbols@^1.0.0, has-symbols@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
+  resolved "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
 
 has@^1.0.3:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  resolved "https://registry.npmjs.org/has/-/has-1.0.3.tgz"
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
 
+hasown@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz"
+  integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+  dependencies:
+    function-bind "^1.1.2"
+
 hosted-git-info@^2.1.4:
   version "2.8.9"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
+  resolved "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
 human-signals@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
+  resolved "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
 husky@^7.0.4:
   version "7.0.4"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.4.tgz#242048245dc49c8fb1bf0cc7cfb98dd722531535"
+  resolved "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz"
   integrity sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==
 
 ignore@^4.0.6:
   version "4.0.6"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
+  resolved "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
 ignore@^5.1.4:
   version "5.1.8"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
+  resolved "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
 import-cwd@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-3.0.0.tgz#20845547718015126ea9b3676b7592fb8bd4cf92"
+  resolved "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz"
   integrity sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==
   dependencies:
     import-from "^3.0.0"
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.2.1"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
+  resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz"
   integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
   dependencies:
     parent-module "^1.0.0"
@@ -1095,130 +1188,144 @@ import-fresh@^3.0.0, import-fresh@^3.2.1:
 
 import-from@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/import-from/-/import-from-3.0.0.tgz#055cfec38cd5a27d8057ca51376d7d3bf0891966"
+  resolved "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz"
   integrity sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==
   dependencies:
     resolve-from "^5.0.0"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
-  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
-  integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
+  resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
+  integrity sha1-khi5srkoojixPcT7a21XbyMUU+o= sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
 indent-string@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  resolved "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
 indexes-of@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
-  integrity sha1-8w9xbI4r00bHtn0985FVZqfAVgc=
+  resolved "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
+  integrity sha1-8w9xbI4r00bHtn0985FVZqfAVgc= sha512-bup+4tap3Hympa+JBJUG7XuOsdNQ6fxt0MHyXMKuLBKn0OqsTfvUxkUrroEX1+B2VsSHvCjiIcZVxRtYa4nllA==
 
 inflight@^1.0.4:
   version "1.0.6"
-  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
-  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
+  resolved "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk= sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
   dependencies:
     once "^1.3.0"
     wrappy "1"
 
 inherits@2:
   version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 is-arrayish@^0.2.1:
   version "0.2.1"
-  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
-  integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+  resolved "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+  integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0= sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
 
 is-binary-path@~2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  resolved "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz"
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
 
+is-builtin-module@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz"
+  integrity sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==
+  dependencies:
+    builtin-modules "^3.3.0"
+
 is-callable@^1.1.4, is-callable@^1.2.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.0.tgz#83336560b54a38e35e3a2df7afd0454d691468bb"
+  resolved "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz"
   integrity sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
+
+is-core-module@^2.13.0:
+  version "2.15.1"
+  resolved "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz"
+  integrity sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==
+  dependencies:
+    hasown "^2.0.2"
 
 is-date-object@^1.0.1:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
+  resolved "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz"
   integrity sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
 
 is-extglob@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
-  integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
+  resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
+  integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI= sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
 
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
+  resolved "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
 
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz"
+  integrity sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==
+
 is-number@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  resolved "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
 is-obj@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
-  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
+  resolved "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz"
+  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8= sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==
 
 is-regex@^1.1.0:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.1.tgz#c6f98aacc546f6cec5468a07b7b153ab564a57b9"
+  resolved "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz"
   integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
   dependencies:
     has-symbols "^1.0.1"
 
 is-regexp@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
-  integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
+  resolved "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz"
+  integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk= sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==
 
 is-stream@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
+  resolved "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
 is-symbol@^1.0.2:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
+  resolved "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz"
   integrity sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
   dependencies:
     has-symbols "^1.0.1"
 
 isexe@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
-  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
-
-js-base64@^2.1.9:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
-  integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
+  resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA= sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
 js-tokens@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1:
   version "3.14.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz"
   integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
   dependencies:
     argparse "^1.0.7"
@@ -1226,27 +1333,27 @@ js-yaml@^3.13.1:
 
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
+  resolved "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
 json-schema-traverse@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
-  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+  resolved "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz"
+  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE= sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
 jsonfile@^6.0.1:
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.0.1.tgz#98966cba214378c8c84b82e085907b40bf614179"
+  resolved "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz"
   integrity sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==
   dependencies:
     universalify "^1.0.0"
@@ -1255,7 +1362,7 @@ jsonfile@^6.0.1:
 
 levn@^0.4.1:
   version "0.4.1"
-  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  resolved "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz"
   integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
   dependencies:
     prelude-ls "^1.2.1"
@@ -1263,24 +1370,24 @@ levn@^0.4.1:
 
 lilconfig@^2.0.3:
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.3.tgz#68f3005e921dafbd2a2afb48379986aa6d2579fd"
+  resolved "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.3.tgz"
   integrity sha512-EHKqr/+ZvdKCifpNrJCKxBTgk5XupZA3y/aCPY9mxfgBzmgh93Mt/WqjjQ38oMxXuvDokaKiM3lAgvSH2sjtHg==
 
 lines-and-columns@^1.1.6:
   version "1.1.6"
-  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
-  integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
+  resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz"
+  integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA= sha512-8ZmlJFVK9iCmtLz19HpSsR8HaAMWBT284VMNednLwlIMDP2hJDCIhUp0IZ2xUcZ+Ob6BM0VvCSJwzASDM45NLQ==
 
 linkify-it@^3.0.1:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.2.tgz#f55eeb8bc1d3ae754049e124ab3bb56d97797fb8"
+  resolved "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.2.tgz"
   integrity sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==
   dependencies:
     uc.micro "^1.0.1"
 
 lint-staged@^11.2.6:
   version "11.2.6"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-11.2.6.tgz#f477b1af0294db054e5937f171679df63baa4c43"
+  resolved "https://registry.npmjs.org/lint-staged/-/lint-staged-11.2.6.tgz"
   integrity sha512-Vti55pUnpvPE0J9936lKl0ngVeTdSZpEdTNhASbkaWX7J5R9OEifo1INBGQuGW4zmy6OG+TcWPJ3m5yuy5Q8Tg==
   dependencies:
     cli-truncate "2.1.0"
@@ -1300,7 +1407,7 @@ lint-staged@^11.2.6:
 
 listr2@^3.12.2:
   version "3.12.2"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.12.2.tgz#2d55cc627111603ad4768a9e87c9c7bb9b49997e"
+  resolved "https://registry.npmjs.org/listr2/-/listr2-3.12.2.tgz"
   integrity sha512-64xC2CJ/As/xgVI3wbhlPWVPx0wfTqbUAkpb7bjDi0thSWMqrf07UFhrfsGoo8YSXmF049Rp9C0cjLC8rZxK9A==
   dependencies:
     cli-truncate "^2.1.0"
@@ -1313,87 +1420,67 @@ listr2@^3.12.2:
 
 load-json-file@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
-  integrity sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
+  resolved "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz"
+  integrity sha1-L19Fq5HjMhYjT9U62rZo607AmTs= sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==
   dependencies:
     graceful-fs "^4.1.2"
     parse-json "^4.0.0"
     pify "^3.0.0"
     strip-bom "^3.0.0"
 
-lodash._reinterpolate@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
-  integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
-
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+  resolved "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz"
+  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8= sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
 
 lodash.difference@^4.5.0:
   version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
-  integrity sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=
+  resolved "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz"
+  integrity sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw= sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==
 
 lodash.forown@^4.4.0:
   version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.forown/-/lodash.forown-4.4.0.tgz#85115cf04f73ef966eced52511d3893cc46683af"
-  integrity sha1-hRFc8E9z75ZuztUlEdOJPMRmg68=
+  resolved "https://registry.npmjs.org/lodash.forown/-/lodash.forown-4.4.0.tgz"
+  integrity sha1-hRFc8E9z75ZuztUlEdOJPMRmg68= sha512-xcpca6BCshoe5SFSrQOoV8FBEbNzcBa6QQYmtv48eEFNzdwQLkHkcWSaBlecHhyHb1BUk1xqFdXoiSLJkt/w5w==
 
 lodash.get@^4.4.2:
   version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+  resolved "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk= sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
 lodash.groupby@^4.6.0:
   version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.groupby/-/lodash.groupby-4.6.0.tgz#0b08a1dcf68397c397855c3239783832df7403d1"
-  integrity sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E=
+  resolved "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz"
+  integrity sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E= sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==
 
 lodash.memoize@^4.1.2:
   version "4.1.2"
-  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
-  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+  resolved "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz"
+  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4= sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
 
 lodash.merge@^4.6.2:
   version "4.6.2"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
-  integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
-
-lodash.template@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
-  integrity sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==
-  dependencies:
-    lodash._reinterpolate "^3.0.0"
-    lodash.templatesettings "^4.0.0"
-
-lodash.templatesettings@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz#e481310f049d3cf6d47e912ad09313b154f0fb33"
-  integrity sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
-  dependencies:
-    lodash._reinterpolate "^3.0.0"
+  resolved "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz"
+  integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg= sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==
 
 lodash.truncate@^4.4.2:
   version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
-  integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
+  resolved "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz"
+  integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM= sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
 lodash.uniq@^4.5.0:
   version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
-  integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
+  resolved "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz"
+  integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M= sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
 
 log-update@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/log-update/-/log-update-4.0.0.tgz#589ecd352471f2a1c0c570287543a64dfd20e0a1"
+  resolved "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz"
   integrity sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==
   dependencies:
     ansi-escapes "^4.3.0"
@@ -1403,7 +1490,7 @@ log-update@^4.0.0:
 
 markdown-it@^12.3.2:
   version "12.3.2"
-  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.3.2.tgz#bf92ac92283fe983fe4de8ff8abfb5ad72cd0c90"
+  resolved "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz"
   integrity sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==
   dependencies:
     argparse "^2.0.1"
@@ -1414,77 +1501,77 @@ markdown-it@^12.3.2:
 
 mdn-data@2.0.14:
   version "2.0.14"
-  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
+  resolved "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz"
   integrity sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
 
 mdurl@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
-  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
+  resolved "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz"
+  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4= sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==
 
 memorystream@^0.3.1:
   version "0.3.1"
-  resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
-  integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI=
+  resolved "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz"
+  integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI= sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==
 
 merge-stream@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
+  resolved "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
 merge2@^1.3.0:
   version "1.4.1"
-  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
 micromatch@^4.0.2, micromatch@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
-  integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
+  version "4.0.8"
+  resolved "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz"
+  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
   dependencies:
-    braces "^3.0.1"
-    picomatch "^2.2.3"
+    braces "^3.0.3"
+    picomatch "^2.3.1"
 
 mimic-fn@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+  resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
 minimatch@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
-  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 
 ms@2.1.2:
   version "2.1.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-nanoid@^3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
-  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
+nanoid@^3.3.7:
+  version "3.3.7"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz"
+  integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
 
 natural-compare@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
-  integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+  resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
+  integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc= sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
 nice-try@^1.0.4:
   version "1.0.5"
-  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+  resolved "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
 node-releases@^2.0.3:
   version "2.0.4"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.4.tgz#f38252370c43854dc48aa431c766c6c398f40476"
+  resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz"
   integrity sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==
 
 normalize-package-data@^2.3.2:
   version "2.5.0"
-  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
+  resolved "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz"
   integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
   dependencies:
     hosted-git-info "^2.1.4"
@@ -1494,22 +1581,22 @@ normalize-package-data@^2.3.2:
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
 normalize-range@^0.1.2:
   version "0.1.2"
-  resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
-  integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
+  resolved "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
+  integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI= sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==
 
 normalize-url@^6.0.1:
   version "6.1.0"
-  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
+  resolved "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz"
   integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
 
 npm-run-all@^4.1.5:
   version "4.1.5"
-  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
+  resolved "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz"
   integrity sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==
   dependencies:
     ansi-styles "^3.2.1"
@@ -1524,36 +1611,36 @@ npm-run-all@^4.1.5:
 
 npm-run-path@^4.0.1:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
+  resolved "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz"
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
 
 nth-check@^2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.0.1.tgz#2efe162f5c3da06a28959fbd3db75dbeea9f0fc2"
+  resolved "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz"
   integrity sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==
   dependencies:
     boolbase "^1.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"
-  resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
-  integrity sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=
+  resolved "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
+  integrity sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4= sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg==
 
 object-inspect@^1.7.0:
   version "1.8.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
+  resolved "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz"
   integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
 
 object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  resolved "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
 object.assign@^4.1.0:
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  resolved "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz"
   integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
   dependencies:
     define-properties "^1.1.2"
@@ -1563,21 +1650,21 @@ object.assign@^4.1.0:
 
 once@^1.3.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
-  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
+  resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E= sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
 
 onetime@^5.1.0, onetime@^5.1.2:
   version "5.1.2"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
+  resolved "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz"
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
 
 optionator@^0.9.1:
   version "0.9.1"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
+  resolved "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz"
   integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
   dependencies:
     deep-is "^0.1.3"
@@ -1589,29 +1676,29 @@ optionator@^0.9.1:
 
 p-map@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b"
+  resolved "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz"
   integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
   dependencies:
     aggregate-error "^3.0.0"
 
 parent-module@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  resolved "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz"
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
 
 parse-json@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
-  integrity sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
+  resolved "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz"
+  integrity sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA= sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==
   dependencies:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
 parse-json@^5.0.0:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.0.1.tgz#7cfe35c1ccd641bce3981467e6c2ece61b3b3878"
+  resolved "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz"
   integrity sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
@@ -1621,76 +1708,81 @@ parse-json@^5.0.0:
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
-  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+  resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18= sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
 path-key@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
-  integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
+  resolved "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz"
+  integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A= sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==
 
 path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.6:
+path-parse@^1.0.7:
   version "1.0.7"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 path-type@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  resolved "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz"
   integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
   dependencies:
     pify "^3.0.0"
 
 path-type@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
+  resolved "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+picocolors@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz"
+  integrity sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==
 
 picocolors@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.2.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
-  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+picocolors@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz"
+  integrity sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==
 
-picomatch@^2.2.3:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
-  integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
 pidtree@^0.3.0:
   version "0.3.1"
-  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.1.tgz#ef09ac2cc0533df1f3250ccf2c4d366b0d12114a"
+  resolved "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz"
   integrity sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==
 
 pify@^2.3.0:
   version "2.3.0"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
-  integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
+  resolved "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+  integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw= sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==
 
 pify@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
-  integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
+  resolved "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
+  integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY= sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"
-  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
+  resolved "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz"
   integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
   dependencies:
     semver-compare "^1.0.0"
 
 postcss-attribute-case-insensitive@^4.0.1:
   version "4.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.2.tgz#d93e46b504589e94ac7277b0463226c68041a880"
+  resolved "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.2.tgz"
   integrity sha512-clkFxk/9pcdb4Vkn0hAHq3YnxBQ2p0CGD1dy24jN+reBck+EWxMbxSUqN4Yj7t0w8csl87K6p0gxBe1utkJsYA==
   dependencies:
     postcss "^7.0.2"
@@ -1698,7 +1790,7 @@ postcss-attribute-case-insensitive@^4.0.1:
 
 postcss-calc@^8.2.0:
   version "8.2.0"
-  resolved "https://registry.yarnpkg.com/postcss-calc/-/postcss-calc-8.2.0.tgz#e67ef8c8456d091c0802968faecf79d0e6e00d24"
+  resolved "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.2.0.tgz"
   integrity sha512-PueXCv288diX7OXyJicGNA6Q3+L4xYb2cALTAeFj9X6PXnj+s4pUf1vkZnwn+rldfu2taCA9ondjF93lhRTPFA==
   dependencies:
     postcss-selector-parser "^6.0.2"
@@ -1706,7 +1798,7 @@ postcss-calc@^8.2.0:
 
 postcss-cli@^8.3.1:
   version "8.3.1"
-  resolved "https://registry.yarnpkg.com/postcss-cli/-/postcss-cli-8.3.1.tgz#865dad08300ac59ae9cecb7066780aa81c767a77"
+  resolved "https://registry.npmjs.org/postcss-cli/-/postcss-cli-8.3.1.tgz"
   integrity sha512-leHXsQRq89S3JC9zw/tKyiVV2jAhnfQe0J8VI4eQQbUjwIe0XxVqLrR+7UsahF1s9wi4GlqP6SJ8ydf44cgF2Q==
   dependencies:
     chalk "^4.0.0"
@@ -1724,7 +1816,7 @@ postcss-cli@^8.3.1:
 
 postcss-color-functional-notation@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-color-functional-notation/-/postcss-color-functional-notation-2.0.1.tgz#5efd37a88fbabeb00a2966d1e53d98ced93f74e0"
+  resolved "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-2.0.1.tgz"
   integrity sha512-ZBARCypjEDofW4P6IdPVTLhDNXPRn8T2s1zHbZidW6rPaaZvcnCS2soYFIQJrMZSxiePJ2XIYTlcb2ztr/eT2g==
   dependencies:
     postcss "^7.0.2"
@@ -1732,7 +1824,7 @@ postcss-color-functional-notation@^2.0.1:
 
 postcss-color-gray@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-color-gray/-/postcss-color-gray-5.0.0.tgz#532a31eb909f8da898ceffe296fdc1f864be8547"
+  resolved "https://registry.npmjs.org/postcss-color-gray/-/postcss-color-gray-5.0.0.tgz"
   integrity sha512-q6BuRnAGKM/ZRpfDascZlIZPjvwsRye7UDNalqVz3s7GDxMtqPY6+Q871liNxsonUw8oC61OG+PSaysYpl1bnw==
   dependencies:
     "@csstools/convert-colors" "^1.4.0"
@@ -1741,7 +1833,7 @@ postcss-color-gray@^5.0.0:
 
 postcss-color-hex-alpha@^5.0.3:
   version "5.0.3"
-  resolved "https://registry.yarnpkg.com/postcss-color-hex-alpha/-/postcss-color-hex-alpha-5.0.3.tgz#a8d9ca4c39d497c9661e374b9c51899ef0f87388"
+  resolved "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-5.0.3.tgz"
   integrity sha512-PF4GDel8q3kkreVXKLAGNpHKilXsZ6xuu+mOQMHWHLPNyjiUBOr75sp5ZKJfmv1MCus5/DWUGcK9hm6qHEnXYw==
   dependencies:
     postcss "^7.0.14"
@@ -1749,7 +1841,7 @@ postcss-color-hex-alpha@^5.0.3:
 
 postcss-color-mod-function@^3.0.3:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/postcss-color-mod-function/-/postcss-color-mod-function-3.0.3.tgz#816ba145ac11cc3cb6baa905a75a49f903e4d31d"
+  resolved "https://registry.npmjs.org/postcss-color-mod-function/-/postcss-color-mod-function-3.0.3.tgz"
   integrity sha512-YP4VG+xufxaVtzV6ZmhEtc+/aTXH3d0JLpnYfxqTvwZPbJhWqp8bSY3nfNzNRFLgB4XSaBA82OE4VjOOKpCdVQ==
   dependencies:
     "@csstools/convert-colors" "^1.4.0"
@@ -1758,7 +1850,7 @@ postcss-color-mod-function@^3.0.3:
 
 postcss-color-rebeccapurple@^4.0.1:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-4.0.1.tgz#c7a89be872bb74e45b1e3022bfe5748823e6de77"
+  resolved "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-4.0.1.tgz"
   integrity sha512-aAe3OhkS6qJXBbqzvZth2Au4V3KieR5sRQ4ptb2b2O8wgvB3SJBsdG+jsn2BZbbwekDG8nTfcCNKcSfe/lEy8g==
   dependencies:
     postcss "^7.0.2"
@@ -1766,7 +1858,7 @@ postcss-color-rebeccapurple@^4.0.1:
 
 postcss-colormin@^5.2.5:
   version "5.2.5"
-  resolved "https://registry.yarnpkg.com/postcss-colormin/-/postcss-colormin-5.2.5.tgz#d1fc269ac2ad03fe641d462b5d1dada35c69968a"
+  resolved "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.2.5.tgz"
   integrity sha512-+X30aDaGYq81mFqwyPpnYInsZQnNpdxMX0ajlY7AExCexEFkPVV+KrO7kXwayqEWL2xwEbNQ4nUO0ZsRWGnevg==
   dependencies:
     browserslist "^4.16.6"
@@ -1776,21 +1868,21 @@ postcss-colormin@^5.2.5:
 
 postcss-convert-values@^5.0.4:
   version "5.0.4"
-  resolved "https://registry.yarnpkg.com/postcss-convert-values/-/postcss-convert-values-5.0.4.tgz#3e74dd97c581f475ae7b4500bc0a7c4fb3a6b1b6"
+  resolved "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.0.4.tgz"
   integrity sha512-bugzSAyjIexdObovsPZu/sBCTHccImJxLyFgeV0MmNBm/Lw5h5XnjfML6gzEmJ3A6nyfCW7hb1JXzcsA4Zfbdw==
   dependencies:
     postcss-value-parser "^4.2.0"
 
 postcss-custom-media@^7.0.8:
   version "7.0.8"
-  resolved "https://registry.yarnpkg.com/postcss-custom-media/-/postcss-custom-media-7.0.8.tgz#fffd13ffeffad73621be5f387076a28b00294e0c"
+  resolved "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-7.0.8.tgz"
   integrity sha512-c9s5iX0Ge15o00HKbuRuTqNndsJUbaXdiNsksnVH8H4gdc+zbLzr/UasOwNG6CTDpLFekVY4672eWdiiWu2GUg==
   dependencies:
     postcss "^7.0.14"
 
 postcss-custom-properties@^8.0.11:
   version "8.0.11"
-  resolved "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-8.0.11.tgz#2d61772d6e92f22f5e0d52602df8fae46fa30d97"
+  resolved "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.11.tgz"
   integrity sha512-nm+o0eLdYqdnJ5abAJeXp4CEU1c1k+eB2yMCvhgzsds/e0umabFrN6HoTy/8Q4K5ilxERdl/JD1LO5ANoYBeMA==
   dependencies:
     postcss "^7.0.17"
@@ -1798,7 +1890,7 @@ postcss-custom-properties@^8.0.11:
 
 postcss-custom-selectors@^5.1.2:
   version "5.1.2"
-  resolved "https://registry.yarnpkg.com/postcss-custom-selectors/-/postcss-custom-selectors-5.1.2.tgz#64858c6eb2ecff2fb41d0b28c9dd7b3db4de7fba"
+  resolved "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-5.1.2.tgz"
   integrity sha512-DSGDhqinCqXqlS4R7KGxL1OSycd1lydugJ1ky4iRXPHdBRiozyMHrdu0H3o7qNOCiZwySZTUI5MV0T8QhCLu+w==
   dependencies:
     postcss "^7.0.2"
@@ -1806,7 +1898,7 @@ postcss-custom-selectors@^5.1.2:
 
 postcss-dir-pseudo-class@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-5.0.0.tgz#6e3a4177d0edb3abcc85fdb6fbb1c26dabaeaba2"
+  resolved "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-5.0.0.tgz"
   integrity sha512-3pm4oq8HYWMZePJY+5ANriPs3P07q+LW6FAdTlkFH2XqDdP4HeeJYMOzn0HYLhRSjBO3fhiqSwwU9xEULSrPgw==
   dependencies:
     postcss "^7.0.2"
@@ -1814,27 +1906,27 @@ postcss-dir-pseudo-class@^5.0.0:
 
 postcss-discard-comments@^5.0.3:
   version "5.0.3"
-  resolved "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-5.0.3.tgz#011acb63418d600fdbe18804e1bbecb543ad2f87"
+  resolved "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.3.tgz"
   integrity sha512-6W5BemziRoqIdAKT+1QjM4bNcJAQ7z7zk073730NHg4cUXh3/rQHHj7pmYxUB9aGhuRhBiUf0pXvIHkRwhQP0Q==
 
 postcss-discard-duplicates@^5.0.3:
   version "5.0.3"
-  resolved "https://registry.yarnpkg.com/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.3.tgz#10f202a4cfe9d407b73dfea7a477054d21ea0c1f"
+  resolved "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.3.tgz"
   integrity sha512-vPtm1Mf+kp7iAENTG7jI1MN1lk+fBqL5y+qxyi4v3H+lzsXEdfS3dwUZD45KVhgzDEgduur8ycB4hMegyMTeRw==
 
 postcss-discard-empty@^5.0.3:
   version "5.0.3"
-  resolved "https://registry.yarnpkg.com/postcss-discard-empty/-/postcss-discard-empty-5.0.3.tgz#ec185af4a3710b88933b0ff751aa157b6041dd6a"
+  resolved "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.3.tgz"
   integrity sha512-xGJugpaXKakwKI7sSdZjUuN4V3zSzb2Y0LOlmTajFbNinEjTfVs9PFW2lmKBaC/E64WwYppfqLD03P8l9BuueA==
 
 postcss-discard-overridden@^5.0.4:
   version "5.0.4"
-  resolved "https://registry.yarnpkg.com/postcss-discard-overridden/-/postcss-discard-overridden-5.0.4.tgz#cc999d6caf18ea16eff8b2b58f48ec3ddee35c9c"
+  resolved "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.4.tgz"
   integrity sha512-3j9QH0Qh1KkdxwiZOW82cId7zdwXVQv/gRXYDnwx5pBtR1sTkU4cXRK9lp5dSdiM0r0OICO/L8J6sV1/7m0kHg==
 
 postcss-double-position-gradients@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-double-position-gradients/-/postcss-double-position-gradients-1.0.0.tgz#fc927d52fddc896cb3a2812ebc5df147e110522e"
+  resolved "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-1.0.0.tgz"
   integrity sha512-G+nV8EnQq25fOI8CH/B6krEohGWnF5+3A6H/+JEpOncu5dCnkS1QQ6+ct3Jkaepw1NGVqqOZH6lqrm244mCftA==
   dependencies:
     postcss "^7.0.5"
@@ -1842,7 +1934,7 @@ postcss-double-position-gradients@^1.0.0:
 
 postcss-env-function@^2.0.2:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-env-function/-/postcss-env-function-2.0.2.tgz#0f3e3d3c57f094a92c2baf4b6241f0b0da5365d7"
+  resolved "https://registry.npmjs.org/postcss-env-function/-/postcss-env-function-2.0.2.tgz"
   integrity sha512-rwac4BuZlITeUbiBq60h/xbLzXY43qOsIErngWa4l7Mt+RaSkT7QBjXVGTcBHupykkblHMDrBFh30zchYPaOUw==
   dependencies:
     postcss "^7.0.2"
@@ -1850,40 +1942,40 @@ postcss-env-function@^2.0.2:
 
 postcss-focus-visible@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-focus-visible/-/postcss-focus-visible-4.0.0.tgz#477d107113ade6024b14128317ade2bd1e17046e"
+  resolved "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-4.0.0.tgz"
   integrity sha512-Z5CkWBw0+idJHSV6+Bgf2peDOFf/x4o+vX/pwcNYrWpXFrSfTkQ3JQ1ojrq9yS+upnAlNRHeg8uEwFTgorjI8g==
   dependencies:
     postcss "^7.0.2"
 
 postcss-focus-within@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-focus-within/-/postcss-focus-within-3.0.0.tgz#763b8788596cee9b874c999201cdde80659ef680"
+  resolved "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-3.0.0.tgz"
   integrity sha512-W0APui8jQeBKbCGZudW37EeMCjDeVxKgiYfIIEo8Bdh5SpB9sxds/Iq8SEuzS0Q4YFOlG7EPFulbbxujpkrV2w==
   dependencies:
     postcss "^7.0.2"
 
 postcss-font-variant@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-font-variant/-/postcss-font-variant-4.0.0.tgz#71dd3c6c10a0d846c5eda07803439617bbbabacc"
+  resolved "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-4.0.0.tgz"
   integrity sha512-M8BFYKOvCrI2aITzDad7kWuXXTm0YhGdP9Q8HanmN4EF1Hmcgs1KK5rSHylt/lUJe8yLxiSwWAHdScoEiIxztg==
   dependencies:
     postcss "^7.0.2"
 
 postcss-gap-properties@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-gap-properties/-/postcss-gap-properties-2.0.0.tgz#431c192ab3ed96a3c3d09f2ff615960f902c1715"
+  resolved "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-2.0.0.tgz"
   integrity sha512-QZSqDaMgXCHuHTEzMsS2KfVDOq7ZFiknSpkrPJY6jmxbugUPTuSzs/vuE5I3zv0WAS+3vhrlqhijiprnuQfzmg==
   dependencies:
     postcss "^7.0.2"
 
 postcss-header@^3.0.1:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-header/-/postcss-header-3.0.1.tgz#2695d7956536590d61e4cca8b7943235005226b4"
+  resolved "https://registry.npmjs.org/postcss-header/-/postcss-header-3.0.1.tgz"
   integrity sha512-bPt7W9yVq7RY7hEs3r9Zy9Q3PhNRq0aLup5+K5Gwt01s7Oeqb0QV7BGtL6fJwTk132/zxzsVe9Gg6gwlXSLZ3A==
 
 postcss-image-set-function@^3.0.1:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-image-set-function/-/postcss-image-set-function-3.0.1.tgz#28920a2f29945bed4c3198d7df6496d410d3f288"
+  resolved "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-3.0.1.tgz"
   integrity sha512-oPTcFFip5LZy8Y/whto91L9xdRHCWEMs3e1MdJxhgt4jy2WYXfhkng59fH5qLXSCPN8k4n94p1Czrfe5IOkKUw==
   dependencies:
     postcss "^7.0.2"
@@ -1891,7 +1983,7 @@ postcss-image-set-function@^3.0.1:
 
 postcss-import@^14.0.2:
   version "14.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-14.0.2.tgz#60eff77e6be92e7b67fe469ec797d9424cae1aa1"
+  resolved "https://registry.npmjs.org/postcss-import/-/postcss-import-14.0.2.tgz"
   integrity sha512-BJ2pVK4KhUyMcqjuKs9RijV5tatNzNa73e/32aBVE/ejYPe37iH+6vAu9WvqUkB5OAYgLHzbSvzHnorybJCm9g==
   dependencies:
     postcss-value-parser "^4.0.0"
@@ -1899,16 +1991,15 @@ postcss-import@^14.0.2:
     resolve "^1.1.7"
 
 postcss-initial@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-initial/-/postcss-initial-3.0.2.tgz#f018563694b3c16ae8eaabe3c585ac6319637b2d"
-  integrity sha512-ugA2wKonC0xeNHgirR4D3VWHs2JcU08WAi1KFLVcnb7IN89phID6Qtg2RIctWbnvp1TM2BOmDtX8GGLCKdR8YA==
+  version "3.0.4"
+  resolved "https://registry.npmjs.org/postcss-initial/-/postcss-initial-3.0.4.tgz"
+  integrity sha512-3RLn6DIpMsK1l5UUy9jxQvoDeUN4gP939tDcKUHD/kM8SGSKbFAnvkpFpj3Bhtz3HGk1jWY5ZNWX6mPta5M9fg==
   dependencies:
-    lodash.template "^4.5.0"
     postcss "^7.0.2"
 
 postcss-lab-function@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-lab-function/-/postcss-lab-function-2.0.1.tgz#bb51a6856cd12289ab4ae20db1e3821ef13d7d2e"
+  resolved "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-2.0.1.tgz"
   integrity sha512-whLy1IeZKY+3fYdqQFuDBf8Auw+qFuVnChWjmxm/UhHWqNHZx+B99EwxTvGYmUBqe3Fjxs4L1BoZTJmPu6usVg==
   dependencies:
     "@csstools/convert-colors" "^1.4.0"
@@ -1917,7 +2008,7 @@ postcss-lab-function@^2.0.1:
 
 postcss-load-config@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-3.0.0.tgz#850bb066edd65b734329eacf83af0c0764226c87"
+  resolved "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.0.0.tgz"
   integrity sha512-lErrN8imuEF1cSiHBV8MiR7HeuzlDpCGNtaMyYHlOBuJHHOGw6S4xOMZp8BbXPr7AGQp14L6PZDlIOpfFJ6f7w==
   dependencies:
     cosmiconfig "^7.0.0"
@@ -1925,21 +2016,21 @@ postcss-load-config@^3.0.0:
 
 postcss-logical@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-logical/-/postcss-logical-3.0.0.tgz#2495d0f8b82e9f262725f75f9401b34e7b45d5b5"
+  resolved "https://registry.npmjs.org/postcss-logical/-/postcss-logical-3.0.0.tgz"
   integrity sha512-1SUKdJc2vuMOmeItqGuNaC+N8MzBWFWEkAnRnLpFYj1tGGa7NqyVBujfRtgNa2gXR+6RkGUiB2O5Vmh7E2RmiA==
   dependencies:
     postcss "^7.0.2"
 
 postcss-media-minmax@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-media-minmax/-/postcss-media-minmax-4.0.0.tgz#b75bb6cbc217c8ac49433e12f22048814a4f5ed5"
+  resolved "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-4.0.0.tgz"
   integrity sha512-fo9moya6qyxsjbFAYl97qKO9gyre3qvbMnkOZeZwlsW6XYFsvs2DMGDlchVLfAd8LHPZDxivu/+qW2SMQeTHBw==
   dependencies:
     postcss "^7.0.2"
 
 postcss-merge-longhand@^5.0.6:
   version "5.0.6"
-  resolved "https://registry.yarnpkg.com/postcss-merge-longhand/-/postcss-merge-longhand-5.0.6.tgz#090e60d5d3b3caad899f8774f8dccb33217d2166"
+  resolved "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.0.6.tgz"
   integrity sha512-rkmoPwQO6ymJSmWsX6l2hHeEBQa7C4kJb9jyi5fZB1sE8nSCv7sqchoYPixRwX/yvLoZP2y6FA5kcjiByeJqDg==
   dependencies:
     postcss-value-parser "^4.2.0"
@@ -1947,7 +2038,7 @@ postcss-merge-longhand@^5.0.6:
 
 postcss-merge-rules@^5.0.6:
   version "5.0.6"
-  resolved "https://registry.yarnpkg.com/postcss-merge-rules/-/postcss-merge-rules-5.0.6.tgz#26b37411fe1e80202fcef61cab027265b8925f2b"
+  resolved "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.0.6.tgz"
   integrity sha512-nzJWJ9yXWp8AOEpn/HFAW72WKVGD2bsLiAmgw4hDchSij27bt6TF+sIK0cJUBAYT3SGcjtGGsOR89bwkkMuMgQ==
   dependencies:
     browserslist "^4.16.6"
@@ -1957,14 +2048,14 @@ postcss-merge-rules@^5.0.6:
 
 postcss-minify-font-values@^5.0.4:
   version "5.0.4"
-  resolved "https://registry.yarnpkg.com/postcss-minify-font-values/-/postcss-minify-font-values-5.0.4.tgz#627d824406b0712243221891f40a44fffe1467fd"
+  resolved "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.0.4.tgz"
   integrity sha512-RN6q3tyuEesvyCYYFCRGJ41J1XFvgV+dvYGHr0CeHv8F00yILlN8Slf4t8XW4IghlfZYCeyRrANO6HpJ948ieA==
   dependencies:
     postcss-value-parser "^4.2.0"
 
 postcss-minify-gradients@^5.0.6:
   version "5.0.6"
-  resolved "https://registry.yarnpkg.com/postcss-minify-gradients/-/postcss-minify-gradients-5.0.6.tgz#b07cef51a93f075e94053fd972ff1cba2eaf6503"
+  resolved "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.0.6.tgz"
   integrity sha512-E/dT6oVxB9nLGUTiY/rG5dX9taugv9cbLNTFad3dKxOO+BQg25Q/xo2z2ddG+ZB1CbkZYaVwx5blY8VC7R/43A==
   dependencies:
     colord "^2.9.1"
@@ -1973,7 +2064,7 @@ postcss-minify-gradients@^5.0.6:
 
 postcss-minify-params@^5.0.5:
   version "5.0.5"
-  resolved "https://registry.yarnpkg.com/postcss-minify-params/-/postcss-minify-params-5.0.5.tgz#86cb624358cd45c21946f8c317893f0449396646"
+  resolved "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.0.5.tgz"
   integrity sha512-YBNuq3Rz5LfLFNHb9wrvm6t859b8qIqfXsWeK7wROm3jSKNpO1Y5e8cOyBv6Acji15TgSrAwb3JkVNCqNyLvBg==
   dependencies:
     browserslist "^4.16.6"
@@ -1982,61 +2073,61 @@ postcss-minify-params@^5.0.5:
 
 postcss-minify-selectors@^5.1.3:
   version "5.1.3"
-  resolved "https://registry.yarnpkg.com/postcss-minify-selectors/-/postcss-minify-selectors-5.1.3.tgz#6ac12d52aa661fd509469d87ab2cebb0a1e3a1b5"
+  resolved "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.1.3.tgz"
   integrity sha512-9RJfTiQEKA/kZhMaEXND893nBqmYQ8qYa/G+uPdVnXF6D/FzpfI6kwBtWEcHx5FqDbA79O9n6fQJfrIj6M8jvQ==
   dependencies:
     postcss-selector-parser "^6.0.5"
 
 postcss-nesting@^7.0.0:
   version "7.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-nesting/-/postcss-nesting-7.0.1.tgz#b50ad7b7f0173e5b5e3880c3501344703e04c052"
+  resolved "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-7.0.1.tgz"
   integrity sha512-FrorPb0H3nuVq0Sff7W2rnc3SmIcruVC6YwpcS+k687VxyxO33iE1amna7wHuRVzM8vfiYofXSBHNAZ3QhLvYg==
   dependencies:
     postcss "^7.0.2"
 
 postcss-normalize-charset@^5.0.3:
   version "5.0.3"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-charset/-/postcss-normalize-charset-5.0.3.tgz#719fb9f9ca9835fcbd4fed8d6e0d72a79e7b5472"
+  resolved "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.3.tgz"
   integrity sha512-iKEplDBco9EfH7sx4ut7R2r/dwTnUqyfACf62Unc9UiyFuI7uUqZZtY+u+qp7g8Qszl/U28HIfcsI3pEABWFfA==
 
 postcss-normalize-display-values@^5.0.3:
   version "5.0.3"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-display-values/-/postcss-normalize-display-values-5.0.3.tgz#94cc82e20c51cc4ffba6b36e9618adc1e50db8c1"
+  resolved "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.0.3.tgz"
   integrity sha512-FIV5FY/qs4Ja32jiDb5mVj5iWBlS3N8tFcw2yg98+8MkRgyhtnBgSC0lxU+16AMHbjX5fbSJgw5AXLMolonuRQ==
   dependencies:
     postcss-value-parser "^4.2.0"
 
 postcss-normalize-positions@^5.0.4:
   version "5.0.4"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-positions/-/postcss-normalize-positions-5.0.4.tgz#4001f38c99675437b83277836fb4291887fcc6cc"
+  resolved "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.0.4.tgz"
   integrity sha512-qynirjBX0Lc73ROomZE3lzzmXXTu48/QiEzKgMeqh28+MfuHLsuqC9po4kj84igZqqFGovz8F8hf44hA3dPYmQ==
   dependencies:
     postcss-value-parser "^4.2.0"
 
 postcss-normalize-repeat-style@^5.0.4:
   version "5.0.4"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.0.4.tgz#d005adf9ee45fae78b673031a376c0c871315145"
+  resolved "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.0.4.tgz"
   integrity sha512-Innt+wctD7YpfeDR7r5Ik6krdyppyAg2HBRpX88fo5AYzC1Ut/l3xaxACG0KsbX49cO2n5EB13clPwuYVt8cMA==
   dependencies:
     postcss-value-parser "^4.2.0"
 
 postcss-normalize-string@^5.0.4:
   version "5.0.4"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-string/-/postcss-normalize-string-5.0.4.tgz#b5e00a07597e7aa8a871817bfeac2bfaa59c3333"
+  resolved "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.0.4.tgz"
   integrity sha512-Dfk42l0+A1CDnVpgE606ENvdmksttLynEqTQf5FL3XGQOyqxjbo25+pglCUvziicTxjtI2NLUR6KkxyUWEVubQ==
   dependencies:
     postcss-value-parser "^4.2.0"
 
 postcss-normalize-timing-functions@^5.0.3:
   version "5.0.3"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.0.3.tgz#47210227bfcba5e52650d7a18654337090de7072"
+  resolved "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.0.3.tgz"
   integrity sha512-QRfjvFh11moN4PYnJ7hia4uJXeFotyK3t2jjg8lM9mswleGsNw2Lm3I5wO+l4k1FzK96EFwEVn8X8Ojrp2gP4g==
   dependencies:
     postcss-value-parser "^4.2.0"
 
 postcss-normalize-unicode@^5.0.4:
   version "5.0.4"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-unicode/-/postcss-normalize-unicode-5.0.4.tgz#02866096937005cdb2c17116c690f29505a1623d"
+  resolved "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.0.4.tgz"
   integrity sha512-W79Regn+a+eXTzB+oV/8XJ33s3pDyFTND2yDuUCo0Xa3QSy1HtNIfRVPXNubHxjhlqmMFADr3FSCHT84ITW3ig==
   dependencies:
     browserslist "^4.16.6"
@@ -2044,7 +2135,7 @@ postcss-normalize-unicode@^5.0.4:
 
 postcss-normalize-url@^5.0.5:
   version "5.0.5"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-url/-/postcss-normalize-url-5.0.5.tgz#c39efc12ff119f6f45f0b4f516902b12c8080e3a"
+  resolved "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.0.5.tgz"
   integrity sha512-Ws3tX+PcekYlXh+ycAt0wyzqGthkvVtZ9SZLutMVvHARxcpu4o7vvXcNoiNKyjKuWecnjS6HDI3fjBuDr5MQxQ==
   dependencies:
     normalize-url "^6.0.1"
@@ -2052,14 +2143,14 @@ postcss-normalize-url@^5.0.5:
 
 postcss-normalize-whitespace@^5.0.4:
   version "5.0.4"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.0.4.tgz#1d477e7da23fecef91fc4e37d462272c7b55c5ca"
+  resolved "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.0.4.tgz"
   integrity sha512-wsnuHolYZjMwWZJoTC9jeI2AcjA67v4UuidDrPN9RnX8KIZfE+r2Nd6XZRwHVwUiHmRvKQtxiqo64K+h8/imaw==
   dependencies:
     postcss-value-parser "^4.2.0"
 
 postcss-ordered-values@^5.0.5:
   version "5.0.5"
-  resolved "https://registry.yarnpkg.com/postcss-ordered-values/-/postcss-ordered-values-5.0.5.tgz#e878af822a130c3f3709737e24cb815ca7c6d040"
+  resolved "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.0.5.tgz"
   integrity sha512-mfY7lXpq+8bDEHfP+muqibDPhZ5eP9zgBEF9XRvoQgXcQe2Db3G1wcvjbnfjXG6wYsl+0UIjikqq4ym1V2jGMQ==
   dependencies:
     cssnano-utils "^3.0.2"
@@ -2067,37 +2158,36 @@ postcss-ordered-values@^5.0.5:
 
 postcss-overflow-shorthand@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-overflow-shorthand/-/postcss-overflow-shorthand-2.0.0.tgz#31ecf350e9c6f6ddc250a78f0c3e111f32dd4c30"
+  resolved "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-2.0.0.tgz"
   integrity sha512-aK0fHc9CBNx8jbzMYhshZcEv8LtYnBIRYQD5i7w/K/wS9c2+0NSR6B3OVMu5y0hBHYLcMGjfU+dmWYNKH0I85g==
   dependencies:
     postcss "^7.0.2"
 
 postcss-page-break@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-page-break/-/postcss-page-break-2.0.0.tgz#add52d0e0a528cabe6afee8b46e2abb277df46bf"
+  resolved "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-2.0.0.tgz"
   integrity sha512-tkpTSrLpfLfD9HvgOlJuigLuk39wVTbbd8RKcy8/ugV2bNBUW3xU+AIqyxhDrQr1VUj1RmyJrBn1YWrqUm9zAQ==
   dependencies:
     postcss "^7.0.2"
 
 postcss-place@^4.0.1:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-place/-/postcss-place-4.0.1.tgz#e9f39d33d2dc584e46ee1db45adb77ca9d1dcc62"
+  resolved "https://registry.npmjs.org/postcss-place/-/postcss-place-4.0.1.tgz"
   integrity sha512-Zb6byCSLkgRKLODj/5mQugyuj9bvAAw9LqJJjgwz5cYryGeXfFZfSXoP1UfveccFmeq0b/2xxwcTEVScnqGxBg==
   dependencies:
     postcss "^7.0.2"
     postcss-values-parser "^2.0.0"
 
-postcss-prefixer@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/postcss-prefixer/-/postcss-prefixer-2.1.3.tgz#828b96aa9a8675bb4a7f66b89dc1bf9e29bf4502"
-  integrity sha512-1ixOH5d9bt/YXw3iJ8FmBAqdviVTj1pdYSDvUDz4dY95tX/hKDXMa34YkQvXGRKkAMoehUd5pKVaF+D1qTbQOg==
+postcss-prefixer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/postcss-prefixer/-/postcss-prefixer-3.0.0.tgz"
+  integrity sha512-q5JEBO8KcJheLLK9RezOw6a26Kdvr2bmPXiK2rsU/5G4h/b6lQh2PhmhvTHvogLQnRUgTNGw76WOiIoiJh+2tw==
   dependencies:
     css-selector-tokenizer "^0.7.2"
-    postcss "^5.2.18"
 
 postcss-preset-env@^6.7.0:
   version "6.7.0"
-  resolved "https://registry.yarnpkg.com/postcss-preset-env/-/postcss-preset-env-6.7.0.tgz#c34ddacf8f902383b35ad1e030f178f4cdf118a5"
+  resolved "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-6.7.0.tgz"
   integrity sha512-eU4/K5xzSFwUFJ8hTdTQzo2RBLbDVt83QZrAvI07TULOkmyQlnYlpwep+2yIK+K+0KlZO4BvFcleOCCcUtwchg==
   dependencies:
     autoprefixer "^9.6.1"
@@ -2140,7 +2230,7 @@ postcss-preset-env@^6.7.0:
 
 postcss-pseudo-class-any-link@^6.0.0:
   version "6.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-6.0.0.tgz#2ed3eed393b3702879dec4a87032b210daeb04d1"
+  resolved "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-6.0.0.tgz"
   integrity sha512-lgXW9sYJdLqtmw23otOzrtbDXofUdfYzNm4PIpNE322/swES3VU9XlXHeJS46zT2onFO7V1QFdD4Q9LiZj8mew==
   dependencies:
     postcss "^7.0.2"
@@ -2148,7 +2238,7 @@ postcss-pseudo-class-any-link@^6.0.0:
 
 postcss-reduce-initial@^5.0.3:
   version "5.0.3"
-  resolved "https://registry.yarnpkg.com/postcss-reduce-initial/-/postcss-reduce-initial-5.0.3.tgz#68891594defd648253703bbd8f1093162f19568d"
+  resolved "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.0.3.tgz"
   integrity sha512-c88TkSnQ/Dnwgb4OZbKPOBbCaauwEjbECP5uAuFPOzQ+XdjNjRH7SG0dteXrpp1LlIFEKK76iUGgmw2V0xeieA==
   dependencies:
     browserslist "^4.16.6"
@@ -2156,21 +2246,21 @@ postcss-reduce-initial@^5.0.3:
 
 postcss-reduce-transforms@^5.0.4:
   version "5.0.4"
-  resolved "https://registry.yarnpkg.com/postcss-reduce-transforms/-/postcss-reduce-transforms-5.0.4.tgz#717e72d30befe857f7d2784dba10eb1157863712"
+  resolved "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.0.4.tgz"
   integrity sha512-VIJB9SFSaL8B/B7AXb7KHL6/GNNbbCHslgdzS9UDfBZYIA2nx8NLY7iD/BXFSO/1sRUILzBTfHCoW5inP37C5g==
   dependencies:
     postcss-value-parser "^4.2.0"
 
 postcss-replace-overflow-wrap@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-3.0.0.tgz#61b360ffdaedca84c7c918d2b0f0d0ea559ab01c"
+  resolved "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-3.0.0.tgz"
   integrity sha512-2T5hcEHArDT6X9+9dVSPQdo7QHzG4XKclFT8rU5TzJPDN7RIRTbO9c4drUISOVemLj03aezStHCR2AIcr8XLpw==
   dependencies:
     postcss "^7.0.2"
 
 postcss-reporter@^7.0.0:
   version "7.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-reporter/-/postcss-reporter-7.0.2.tgz#03e9e7381c1afe40646f9c22e7aeeb860e051065"
+  resolved "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-7.0.2.tgz"
   integrity sha512-JyQ96NTQQsso42y6L1H1RqHfWH1C3Jr0pt91mVv5IdYddZAE9DUZxuferNgk6q0o6vBVOrfVJb10X1FgDzjmDw==
   dependencies:
     colorette "^1.2.1"
@@ -2182,7 +2272,7 @@ postcss-reporter@^7.0.0:
 
 postcss-selector-matches@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-selector-matches/-/postcss-selector-matches-4.0.0.tgz#71c8248f917ba2cc93037c9637ee09c64436fcff"
+  resolved "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-4.0.0.tgz"
   integrity sha512-LgsHwQR/EsRYSqlwdGzeaPKVT0Ml7LAT6E75T8W8xLJY62CE4S/l03BWIt3jT8Taq22kXP08s2SfTSzaraoPww==
   dependencies:
     balanced-match "^1.0.0"
@@ -2190,33 +2280,33 @@ postcss-selector-matches@^4.0.0:
 
 postcss-selector-not@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-selector-not/-/postcss-selector-not-4.0.0.tgz#c68ff7ba96527499e832724a2674d65603b645c0"
+  resolved "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-4.0.0.tgz"
   integrity sha512-W+bkBZRhqJaYN8XAnbbZPLWMvZD1wKTu0UxtFKdhtGjWYmxhkUneoeOhRJKdAE5V7ZTlnbHfCR+6bNwK9e1dTQ==
   dependencies:
     balanced-match "^1.0.0"
     postcss "^7.0.2"
 
-postcss-selector-parser@^5.0.0-rc.3, postcss-selector-parser@^5.0.0-rc.4:
+postcss-selector-parser@^5.0.0-rc.3:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz#249044356697b33b64f1a8f7c80922dddee7195c"
+  resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz"
   integrity sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==
   dependencies:
     cssesc "^2.0.0"
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss-selector-parser@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz#934cf799d016c83411859e09dcecade01286ec5c"
-  integrity sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==
+postcss-selector-parser@^5.0.0-rc.4:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz"
+  integrity sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==
   dependencies:
-    cssesc "^3.0.0"
+    cssesc "^2.0.0"
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss-selector-parser@^6.0.4, postcss-selector-parser@^6.0.5:
+postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4, postcss-selector-parser@^6.0.5:
   version "6.0.6"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz#2c5bba8174ac2f6981ab631a42ab0ee54af332ea"
+  resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz"
   integrity sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==
   dependencies:
     cssesc "^3.0.0"
@@ -2224,7 +2314,7 @@ postcss-selector-parser@^6.0.4, postcss-selector-parser@^6.0.5:
 
 postcss-svgo@^5.0.4:
   version "5.0.4"
-  resolved "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-5.0.4.tgz#cfa8682f47b88f7cd75108ec499e133b43102abf"
+  resolved "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.0.4.tgz"
   integrity sha512-yDKHvULbnZtIrRqhZoA+rxreWpee28JSRH/gy9727u0UCgtpv1M/9WEWY3xySlFa0zQJcqf6oCBJPR5NwkmYpg==
   dependencies:
     postcss-value-parser "^4.2.0"
@@ -2232,89 +2322,117 @@ postcss-svgo@^5.0.4:
 
 postcss-unique-selectors@^5.0.4:
   version "5.0.4"
-  resolved "https://registry.yarnpkg.com/postcss-unique-selectors/-/postcss-unique-selectors-5.0.4.tgz#08e188126b634ddfa615fb1d6c262bafdd64826e"
+  resolved "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.0.4.tgz"
   integrity sha512-5ampwoSDJCxDPoANBIlMgoBcYUHnhaiuLYJR5pj1DLnYQvMRVyFuTA5C3Bvt+aHtiqWpJkD/lXT50Vo1D0ZsAQ==
   dependencies:
     postcss-selector-parser "^6.0.5"
 
 postcss-value-parser@^4.0.0, postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   version "4.2.0"
-  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
+  resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
 postcss-values-parser@^2.0.0, postcss-values-parser@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz#da8b472d901da1e205b47bdc98637b9e9e550e5f"
+  resolved "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz"
   integrity sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==
   dependencies:
     flatten "^1.0.2"
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss@^5.2.18:
-  version "5.2.18"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
-  integrity sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==
+postcss@^7.0.14:
+  version "7.0.39"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz"
+  integrity sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
   dependencies:
-    chalk "^1.1.3"
-    js-base64 "^2.1.9"
-    source-map "^0.5.6"
-    supports-color "^3.2.3"
-
-postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.32, postcss@^7.0.5, postcss@^7.0.6:
-  version "7.0.35"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.35.tgz#d2be00b998f7f211d8a276974079f2e92b970e24"
-  integrity sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==
-  dependencies:
-    chalk "^2.4.2"
+    picocolors "^0.2.1"
     source-map "^0.6.1"
-    supports-color "^6.1.0"
 
-postcss@^8.4.14:
-  version "8.4.14"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.14.tgz#ee9274d5622b4858c1007a74d76e42e56fd21caf"
-  integrity sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==
+postcss@^7.0.17, postcss@^7.0.32:
+  version "7.0.39"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz"
+  integrity sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
   dependencies:
-    nanoid "^3.3.4"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.2"
+    picocolors "^0.2.1"
+    source-map "^0.6.1"
+
+postcss@^7.0.2:
+  version "7.0.39"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz"
+  integrity sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
+  dependencies:
+    picocolors "^0.2.1"
+    source-map "^0.6.1"
+
+postcss@^7.0.5:
+  version "7.0.39"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz"
+  integrity sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
+  dependencies:
+    picocolors "^0.2.1"
+    source-map "^0.6.1"
+
+postcss@^7.0.6:
+  version "7.0.39"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz"
+  integrity sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
+  dependencies:
+    picocolors "^0.2.1"
+    source-map "^0.6.1"
+
+postcss@^8.0.0, postcss@^8.0.9, postcss@^8.1.0, postcss@^8.2.15, postcss@^8.2.2, postcss@^8.4.14:
+  version "8.4.47"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz"
+  integrity sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==
+  dependencies:
+    nanoid "^3.3.7"
+    picocolors "^1.1.0"
+    source-map-js "^1.2.1"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
 prettier@^2.7.1:
   version "2.7.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  resolved "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 pretty-hrtime@^1.0.3:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
-  integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
+  resolved "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz"
+  integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE= sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==
 
 progress@^2.0.0:
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 punycode@^2.1.0:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+randombytes@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz"
+  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
+  dependencies:
+    safe-buffer "^5.1.0"
 
 read-cache@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/read-cache/-/read-cache-1.0.0.tgz#e664ef31161166c9751cdbe8dbcf86b5fb58f774"
-  integrity sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=
+  resolved "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz"
+  integrity sha1-5mTvMRYRZsl1HNvo28+GtftY93Q= sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==
   dependencies:
     pify "^2.3.0"
 
 read-pkg@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
-  integrity sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
+  resolved "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz"
+  integrity sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k= sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==
   dependencies:
     load-json-file "^4.0.0"
     normalize-package-data "^2.3.2"
@@ -2322,46 +2440,48 @@ read-pkg@^3.0.0:
 
 readdirp@~3.4.0:
   version "3.4.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.4.0.tgz#9fdccdf9e9155805449221ac645e8303ab5b9ada"
+  resolved "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz"
   integrity sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==
   dependencies:
     picomatch "^2.2.1"
 
 regexpp@^3.1.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
+  resolved "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
 
 require-directory@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
-  integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+  resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
+  integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I= sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
 require-from-string@^2.0.2:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  resolved "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 resolve-from@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
 resolve-from@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
+  resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-resolve@^1.1.7, resolve@^1.10.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
-  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
+resolve@^1.1.7, resolve@^1.10.0, resolve@^1.22.1:
+  version "1.22.8"
+  resolved "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz"
+  integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
   dependencies:
-    path-parse "^1.0.6"
+    is-core-module "^2.13.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
 
 restore-cursor@^3.1.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
+  resolved "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz"
   integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
   dependencies:
     onetime "^5.1.0"
@@ -2369,85 +2489,102 @@ restore-cursor@^3.1.0:
 
 reusify@^1.0.4:
   version "1.0.4"
-  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
 rimraf@^3.0.2:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
 run-parallel@^1.1.9:
   version "1.1.9"
-  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
+  resolved "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz"
   integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
 
 rxjs@^6.6.7:
   version "6.6.7"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
+  resolved "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
 
+safe-buffer@^5.1.0:
+  version "5.2.1"
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
 semver-compare@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
-  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
+  resolved "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz"
+  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w= sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==
 
-"semver@2 || 3 || 4 || 5", semver@^5.5.0:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
-  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
+semver@^5.5.0:
+  version "5.7.2"
+  resolved "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz"
+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
 semver@^7.2.1:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
-  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+  version "7.6.3"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz"
+  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
+
+"semver@2 || 3 || 4 || 5":
+  version "5.7.2"
+  resolved "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz"
+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
+
+serialize-javascript@^6.0.1:
+  version "6.0.2"
+  resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz"
+  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
+  dependencies:
+    randombytes "^2.1.0"
 
 shebang-command@^1.2.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
-  integrity sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=
+  resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz"
+  integrity sha1-RKrGW2lbAzmJaMOfNj/uXer98eo= sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==
   dependencies:
     shebang-regex "^1.0.0"
 
 shebang-command@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz"
   integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
   dependencies:
     shebang-regex "^3.0.0"
 
 shebang-regex@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
-  integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+  resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+  integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM= sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==
 
 shebang-regex@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shell-quote@^1.6.1:
   version "1.7.3"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
+  resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz"
   integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
 
 signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
+  resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
 slash@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
+  resolved "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
 slice-ansi@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-3.0.0.tgz#31ddc10930a1b7e0b67b08c96c2f49b77a789787"
+  resolved "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz"
   integrity sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==
   dependencies:
     ansi-styles "^4.0.0"
@@ -2456,31 +2593,39 @@ slice-ansi@^3.0.0:
 
 slice-ansi@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
+  resolved "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz"
   integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
   dependencies:
     ansi-styles "^4.0.0"
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
-source-map-js@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
-  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
+smob@^1.0.0:
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/smob/-/smob-1.5.0.tgz"
+  integrity sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==
 
-source-map@^0.5.6:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-  integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
+source-map-js@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
+  integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
-source-map@^0.6.1:
+source-map-support@~0.5.20:
+  version "0.5.21"
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 spdx-correct@^3.0.0:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.1.tgz#dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9"
+  resolved "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz"
   integrity sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==
   dependencies:
     spdx-expression-parse "^3.0.0"
@@ -2488,12 +2633,12 @@ spdx-correct@^3.0.0:
 
 spdx-exceptions@^2.1.0:
   version "2.3.0"
-  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz#3f28ce1a77a00372683eade4a433183527a2163d"
+  resolved "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz"
   integrity sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==
 
 spdx-expression-parse@^3.0.0:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz#cf70f50482eefdc98e3ce0a6833e4a53ceeba679"
+  resolved "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz"
   integrity sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==
   dependencies:
     spdx-exceptions "^2.1.0"
@@ -2501,27 +2646,27 @@ spdx-expression-parse@^3.0.0:
 
 spdx-license-ids@^3.0.0:
   version "3.0.5"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
+  resolved "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz"
   integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
-  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+  resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw= sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
 stable@^0.1.8:
   version "0.1.8"
-  resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
+  resolved "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
 
 string-argv@0.3.1:
   version "0.3.1"
-  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
+  resolved "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
 string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz"
   integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
   dependencies:
     emoji-regex "^8.0.0"
@@ -2530,7 +2675,7 @@ string-width@^4.1.0, string-width@^4.2.0:
 
 string.prototype.padend@^3.0.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/string.prototype.padend/-/string.prototype.padend-3.1.0.tgz#dc08f57a8010dc5c153550318f67e13adbb72ac3"
+  resolved "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.0.tgz"
   integrity sha512-3aIv8Ffdp8EZj8iLwREGpQaUZiPyrWrpzMBHvkiSW/bK/EGve9np07Vwy7IJ5waydpGXzQZu/F8Oze2/IWkBaA==
   dependencies:
     define-properties "^1.1.3"
@@ -2538,7 +2683,7 @@ string.prototype.padend@^3.0.0:
 
 string.prototype.trimend@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"
+  resolved "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz"
   integrity sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==
   dependencies:
     define-properties "^1.1.3"
@@ -2546,7 +2691,7 @@ string.prototype.trimend@^1.0.1:
 
 string.prototype.trimstart@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz#14af6d9f34b053f7cfc89b72f8f2ee14b9039a54"
+  resolved "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz"
   integrity sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==
   dependencies:
     define-properties "^1.1.3"
@@ -2554,93 +2699,72 @@ string.prototype.trimstart@^1.0.1:
 
 stringify-object@3.3.0:
   version "3.3.0"
-  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.3.0.tgz#703065aefca19300d3ce88af4f5b3956d7556629"
+  resolved "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz"
   integrity sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==
   dependencies:
     get-own-enumerable-property-symbols "^3.0.0"
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-strip-ansi@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
-  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
-  dependencies:
-    ansi-regex "^2.0.0"
-
 strip-ansi@^6.0.0:
   version "6.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz"
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
 
 strip-bom@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
-  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
+  resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM= sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==
 
 strip-final-newline@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
+  resolved "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
 strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
 stylehacks@^5.0.3:
   version "5.0.3"
-  resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-5.0.3.tgz#2ef3de567bfa2be716d29a93bf3d208c133e8d04"
+  resolved "https://registry.npmjs.org/stylehacks/-/stylehacks-5.0.3.tgz"
   integrity sha512-ENcUdpf4yO0E1rubu8rkxI+JGQk4CgjchynZ4bDBJDfqdy+uhTRSWb8/F3Jtu+Bw5MW45Po3/aQGeIyyxgQtxg==
   dependencies:
     browserslist "^4.16.6"
     postcss-selector-parser "^6.0.4"
 
-supports-color@8.1.1:
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
-  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
-  dependencies:
-    has-flag "^4.0.0"
-
-supports-color@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
-  integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
-
-supports-color@^3.2.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
-  integrity sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=
-  dependencies:
-    has-flag "^1.0.0"
-
 supports-color@^5.3.0:
   version "5.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
-  dependencies:
-    has-flag "^3.0.0"
-
-supports-color@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
-  integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
 
 supports-color@^7.1.0:
   version "7.1.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz"
   integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
   dependencies:
     has-flag "^4.0.0"
 
+supports-color@8.1.1:
+  version "8.1.1"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
 svgo@^2.7.0:
   version "2.8.0"
-  resolved "https://registry.yarnpkg.com/svgo/-/svgo-2.8.0.tgz#4ff80cce6710dc2795f0c7c74101e6764cfccd24"
+  resolved "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz"
   integrity sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==
   dependencies:
     "@trysound/sax" "0.2.0"
@@ -2653,7 +2777,7 @@ svgo@^2.7.0:
 
 table@^6.0.9:
   version "6.7.1"
-  resolved "https://registry.yarnpkg.com/table/-/table-6.7.1.tgz#ee05592b7143831a8c94f3cee6aae4c1ccef33e2"
+  resolved "https://registry.npmjs.org/table/-/table-6.7.1.tgz"
   integrity sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==
   dependencies:
     ajv "^8.0.1"
@@ -2663,85 +2787,95 @@ table@^6.0.9:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
 
+terser@^5.17.4:
+  version "5.32.0"
+  resolved "https://registry.npmjs.org/terser/-/terser-5.32.0.tgz"
+  integrity sha512-v3Gtw3IzpBJ0ugkxEX8U0W6+TnPKRRCWGh1jC/iM/e3Ki5+qvO1L1EAZ56bZasc64aXHwRHNIQEzm6//i5cemQ==
+  dependencies:
+    "@jridgewell/source-map" "^0.3.3"
+    acorn "^8.8.2"
+    commander "^2.20.0"
+    source-map-support "~0.5.20"
+
 text-table@^0.2.0:
   version "0.2.0"
-  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
-  integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+  resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+  integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ= sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
 through@^2.3.8:
   version "2.3.8"
-  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
-  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+  resolved "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU= sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
 timsort@^0.3.0:
   version "0.3.0"
-  resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
-  integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
+  resolved "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz"
+  integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q= sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  resolved "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz"
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
 
 tslib@^1.9.0:
   version "1.13.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
-  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  resolved "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz"
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
 
 type-fest@^0.11.0:
   version "0.11.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz"
   integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
 
 type-fest@^0.20.2:
   version "0.20.2"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
-  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  resolved "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz"
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 uniq@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
-  integrity sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=
+  resolved "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
+  integrity sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8= sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==
 
 universalify@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
+  resolved "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz"
   integrity sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
 
 uri-js@^4.2.2:
   version "4.2.2"
-  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  resolved "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz"
   integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
   dependencies:
     punycode "^2.1.0"
 
 util-deprecate@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+  resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8= sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 v8-compile-cache@^2.0.3:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"
+  resolved "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz"
   integrity sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
+  resolved "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz"
   integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
   dependencies:
     spdx-correct "^3.0.0"
@@ -2749,26 +2883,26 @@ validate-npm-package-license@^3.0.1:
 
 which@^1.2.9:
   version "1.3.1"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  resolved "https://registry.npmjs.org/which/-/which-1.3.1.tgz"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
 
 which@^2.0.1:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  resolved "https://registry.npmjs.org/which/-/which-2.0.2.tgz"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 
 word-wrap@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
-  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+  version "1.2.5"
+  resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz"
+  integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
 wrap-ansi@^6.2.0:
   version "6.2.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
   dependencies:
     ansi-styles "^4.0.0"
@@ -2777,7 +2911,7 @@ wrap-ansi@^6.2.0:
 
 wrap-ansi@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
@@ -2786,27 +2920,27 @@ wrap-ansi@^7.0.0:
 
 wrappy@1:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+  resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8= sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
 y18n@^5.0.5:
   version "5.0.5"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
+  resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz"
   integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
 
 yaml@^1.10.0, yaml@^1.10.2:
   version "1.10.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yargs-parser@^20.2.2:
   version "20.2.4"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
 yargs@^16.0.0:
   version "16.2.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
   dependencies:
     cliui "^7.0.2"


### PR DESCRIPTION
# Idea : 

Since March 2020, the `Element` class, which serves as the base class for all `HTMLElement`, `SVGElement`, and `MathMLElement` instances, has incorporated a feature known as animate.

The `animate` method in the Element class provides a way to create animations directly on DOM elements using the Web Animations API. This method allows you to animate CSS properties or other attributes of an element over a specified duration.

As I am developing a JavaScript library named **[ziko.js](https://github.com/zakarialaoui10/ziko.js)**, which utilizes DOM nodes to create and manipulate user interfaces, I have also adopted this `.animate()` feature. While working on built-in animations for the library, I discovered your library and decided to aimplemnt its JavaScript.

So all libraries that use this hyperscript approach can use it as well as the dom element .

# Usage :

- **With Dom node :**
```js
 let element = document.querySelector(/* selector */);
 let {keyframes, config} = bounce(1000, 2, "ease");
 element.animate(keyframes, config)
```
- **With zikojs :**
```js
 import {text} from "ziko"
 import {bounce} from "animate.css/js"
 let txt= text("Hello from zikojs").style({
    color : "darkblue"
 });
 let {keyframes, config} = bounce(1000, 2, "ease")
 txt.animate(keyframes, config)
``` 