### PR TITLE
Fix #1793: Added animation-delay variable support

### DIFF
--- a/animate.css
+++ b/animate.css
@@ -17,6 +17,8 @@
   animation-duration: 1s;
   -webkit-animation-duration: var(--animate-duration);
   animation-duration: var(--animate-duration);
+  -webkit-animation-delay: var(--animate-delay);
+  animation-delay: var(--animate-delay);
   -webkit-animation-fill-mode: both;
   animation-fill-mode: both;
 }


### PR DESCRIPTION
Fixes #1793, which requested the ability to set animation delays.

In this pull request, I’ve added support for an animation-delay variable to the animate.css library. This means users can now specify a delay before their animations start.

Previously, there wasn’t a way to delay animations

To try out the new feature, users can now use the --animate-delay variable in their CSS. For example, you can set it 
like this: --animate-delay: 2s; .